### PR TITLE
Improve ECDSA verification speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "graviola"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-graviola"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "env_logger",
  "graviola",

--- a/graviola/Cargo.toml
+++ b/graviola/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graviola"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.1"
 edition = "2021"
 repository = "https://github.com/ctz/graviola/"
 license = "Apache-2.0 OR ISC OR MIT-0"

--- a/rustls-graviola/Cargo.toml
+++ b/rustls-graviola/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-graviola"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.1"
 edition = "2021"
 repository = "https://github.com/ctz/graviola/"
 license = "Apache-2.0 OR ISC OR MIT-0"
@@ -10,7 +10,7 @@ rust-version = "1.72"
 readme = "README.md"
 
 [dependencies]
-graviola = { version = "0.2.0-alpha.0", path = "../graviola" }
+graviola = { version = "0.2.0-alpha.1", path = "../graviola" }
 rustls = { version = "0.23.13", default-features = false, features = ["tls12"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
Previously we only had secret-scalar point multiplication. This introduces public-scalar point multiplication, and then uses it in `ecdsa_raw_verify()`