### PR TITLE
x25519: check shared secret for zero

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -6,7 +6,7 @@ cargo llvm-cov show-env --export-prefix "$@" > envsh
 source ./envsh
 cargo llvm-cov clean --workspace
 
-cargo test --locked --all-features
+env SLOW_TESTS=1 cargo test --locked --all-features
 
 if [ `uname -p` == "x86_64" ] ; then
     env GRAVIOLA_CPU_DISABLE_sha=1 GRAVIOLA_CPU_DISABLE_bmi2=1 cargo test --locked

--- a/graviola/src/lib.rs
+++ b/graviola/src/lib.rs
@@ -70,8 +70,8 @@ pub mod key_agreement {
     /// let alice_pub = alice.public_key();
     /// let bob_pub = bob.public_key();
     ///
-    /// let alice_shared_secret = alice.diffie_hellman(&bob_pub);
-    /// let bob_shared_secret = bob.diffie_hellman(&alice_pub);
+    /// let alice_shared_secret = alice.diffie_hellman(&bob_pub).unwrap();
+    /// let bob_shared_secret = bob.diffie_hellman(&alice_pub).unwrap();
     /// assert_eq!(alice_shared_secret.0, bob_shared_secret.0);
     /// ```
     ///

--- a/graviola/tests/wycheproof.rs
+++ b/graviola/tests/wycheproof.rs
@@ -440,8 +440,10 @@ fn test_ecdh_x25519() {
 
             let private = x25519::StaticPrivateKey::try_from_slice(&test.private).unwrap();
             let result = x25519::PublicKey::try_from_slice(&test.public)
-                .and_then(|pubkey| Ok(private.diffie_hellman(&pubkey)));
+                .and_then(|pubkey| private.diffie_hellman(&pubkey));
             match (test.result, &result) {
+                (ExpectedResult::Acceptable, Err(Error::NotOnCurve))
+                    if test.has_flag("ZeroSharedSecret") => {}
                 (ExpectedResult::Valid | ExpectedResult::Acceptable, Ok(shared)) => {
                     assert_eq!(&shared.0[..], &test.shared)
                 }

--- a/rustls-graviola/src/kx.rs
+++ b/rustls-graviola/src/kx.rs
@@ -42,9 +42,9 @@ struct ActiveX25519 {
 
 impl crypto::ActiveKeyExchange for ActiveX25519 {
     fn complete(self: Box<Self>, peer: &[u8]) -> Result<crypto::SharedSecret, rustls::Error> {
-        let their_pub = x25519::PublicKey::try_from_slice(peer)
+        let shared_secret = x25519::PublicKey::try_from_slice(peer)
+            .and_then(|their_pub| self.priv_key.diffie_hellman(&their_pub))
             .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))?;
-        let shared_secret = self.priv_key.diffie_hellman(&their_pub);
         Ok(crypto::SharedSecret::from(&shared_secret.0[..]))
     }
 


### PR DESCRIPTION
This is allowed but not required by RFC7748. TLS does not require it, but other uses might.