### PR TITLE
euristic to avoid `Q!("single string")` noise

### DIFF
--- a/admin/parse-asm/driver.py
+++ b/admin/parse-asm/driver.py
@@ -751,8 +751,14 @@ use crate::low::macros::*;
             assert len(value) == 1
             self.register_rust_macro(tokens[0], value)
             value = self.expand_rust_macros_in_macro_decl(*value, indent=0)
+
+            if value.count('"') == 2 and value[0] == '"' and value[-1] == '"':
+                # avoid extra Q! noise if not needed
+                value = value
+            else:
+                value = 'Q!(%s)' % value
             print(
-                """macro_rules! %s { () => { Q!(%s) } }""" % (tokens[0], value),
+                """macro_rules! %s { () => { %s } }""" % (tokens[0], value),
                 file=f,
             )
         else:

--- a/graviola/src/low/aarch64/bignum_add.rs
+++ b/graviola/src/low/aarch64/bignum_add.rs
@@ -22,47 +22,47 @@ use crate::low::macros::*;
 
 macro_rules! p {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! n {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! d {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_add_p256.rs
+++ b/graviola/src/low/aarch64/bignum_add_p256.rs
@@ -17,62 +17,62 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! d0 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! n0 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! n1 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! n2 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_add_p384.rs
+++ b/graviola/src/low/aarch64/bignum_add_p384.rs
@@ -17,57 +17,57 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d0 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_bitsize.rs
+++ b/graviola/src/low/aarch64/bignum_bitsize.rs
@@ -21,32 +21,32 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! w {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_cmp_lt.rs
+++ b/graviola/src/low/aarch64/bignum_cmp_lt.rs
@@ -17,37 +17,37 @@ use crate::low::macros::*;
 
 macro_rules! m {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! n {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_copy_row_from_table.rs
+++ b/graviola/src/low/aarch64/bignum_copy_row_from_table.rs
@@ -21,43 +21,43 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! table {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! height {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! width {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! idx {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 
 macro_rules! i {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! mask {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_copy_row_from_table_16_neon.rs
+++ b/graviola/src/low/aarch64/bignum_copy_row_from_table_16_neon.rs
@@ -25,136 +25,136 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! tbl {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! height {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! idx {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
 macro_rules! mask {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! cnt {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 
 macro_rules! ventry0 {
     () => {
-        Q!("v20")
+        "v20"
     };
 }
 macro_rules! qentry0 {
     () => {
-        Q!("q20")
+        "q20"
     };
 }
 macro_rules! ventry1 {
     () => {
-        Q!("v21")
+        "v21"
     };
 }
 macro_rules! qentry1 {
     () => {
-        Q!("q21")
+        "q21"
     };
 }
 macro_rules! ventry2 {
     () => {
-        Q!("v22")
+        "v22"
     };
 }
 macro_rules! qentry2 {
     () => {
-        Q!("q22")
+        "q22"
     };
 }
 macro_rules! ventry3 {
     () => {
-        Q!("v23")
+        "v23"
     };
 }
 macro_rules! qentry3 {
     () => {
-        Q!("q23")
+        "q23"
     };
 }
 macro_rules! ventry4 {
     () => {
-        Q!("v24")
+        "v24"
     };
 }
 macro_rules! qentry4 {
     () => {
-        Q!("q24")
+        "q24"
     };
 }
 macro_rules! ventry5 {
     () => {
-        Q!("v25")
+        "v25"
     };
 }
 macro_rules! qentry5 {
     () => {
-        Q!("q25")
+        "q25"
     };
 }
 macro_rules! ventry6 {
     () => {
-        Q!("v26")
+        "v26"
     };
 }
 macro_rules! qentry6 {
     () => {
-        Q!("q26")
+        "q26"
     };
 }
 macro_rules! ventry7 {
     () => {
-        Q!("v27")
+        "v27"
     };
 }
 macro_rules! qentry7 {
     () => {
-        Q!("q27")
+        "q27"
     };
 }
 macro_rules! ventry8 {
     () => {
-        Q!("v28")
+        "v28"
     };
 }
 
 macro_rules! vtmp {
     () => {
-        Q!("v16")
+        "v16"
     };
 }
 macro_rules! qtmp {
     () => {
-        Q!("q16")
+        "q16"
     };
 }
 
 macro_rules! vmask {
     () => {
-        Q!("v17")
+        "v17"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_copy_row_from_table_32_neon.rs
+++ b/graviola/src/low/aarch64/bignum_copy_row_from_table_32_neon.rs
@@ -25,211 +25,211 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! tbl {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! height {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! idx {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
 macro_rules! mask {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! cnt {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 
 macro_rules! ventry0 {
     () => {
-        Q!("v20")
+        "v20"
     };
 }
 macro_rules! qentry0 {
     () => {
-        Q!("q20")
+        "q20"
     };
 }
 macro_rules! ventry1 {
     () => {
-        Q!("v21")
+        "v21"
     };
 }
 macro_rules! qentry1 {
     () => {
-        Q!("q21")
+        "q21"
     };
 }
 macro_rules! ventry2 {
     () => {
-        Q!("v22")
+        "v22"
     };
 }
 macro_rules! qentry2 {
     () => {
-        Q!("q22")
+        "q22"
     };
 }
 macro_rules! ventry3 {
     () => {
-        Q!("v23")
+        "v23"
     };
 }
 macro_rules! qentry3 {
     () => {
-        Q!("q23")
+        "q23"
     };
 }
 macro_rules! ventry4 {
     () => {
-        Q!("v24")
+        "v24"
     };
 }
 macro_rules! qentry4 {
     () => {
-        Q!("q24")
+        "q24"
     };
 }
 macro_rules! ventry5 {
     () => {
-        Q!("v25")
+        "v25"
     };
 }
 macro_rules! qentry5 {
     () => {
-        Q!("q25")
+        "q25"
     };
 }
 macro_rules! ventry6 {
     () => {
-        Q!("v26")
+        "v26"
     };
 }
 macro_rules! qentry6 {
     () => {
-        Q!("q26")
+        "q26"
     };
 }
 macro_rules! ventry7 {
     () => {
-        Q!("v27")
+        "v27"
     };
 }
 macro_rules! qentry7 {
     () => {
-        Q!("q27")
+        "q27"
     };
 }
 macro_rules! ventry8 {
     () => {
-        Q!("v28")
+        "v28"
     };
 }
 macro_rules! qentry8 {
     () => {
-        Q!("q28")
+        "q28"
     };
 }
 macro_rules! ventry9 {
     () => {
-        Q!("v29")
+        "v29"
     };
 }
 macro_rules! qentry9 {
     () => {
-        Q!("q29")
+        "q29"
     };
 }
 macro_rules! ventry10 {
     () => {
-        Q!("v30")
+        "v30"
     };
 }
 macro_rules! qentry10 {
     () => {
-        Q!("q30")
+        "q30"
     };
 }
 macro_rules! ventry11 {
     () => {
-        Q!("v31")
+        "v31"
     };
 }
 macro_rules! qentry11 {
     () => {
-        Q!("q31")
+        "q31"
     };
 }
 macro_rules! ventry12 {
     () => {
-        Q!("v0")
+        "v0"
     };
 }
 macro_rules! qentry12 {
     () => {
-        Q!("q0")
+        "q0"
     };
 }
 macro_rules! ventry13 {
     () => {
-        Q!("v1")
+        "v1"
     };
 }
 macro_rules! qentry13 {
     () => {
-        Q!("q1")
+        "q1"
     };
 }
 macro_rules! ventry14 {
     () => {
-        Q!("v2")
+        "v2"
     };
 }
 macro_rules! qentry14 {
     () => {
-        Q!("q2")
+        "q2"
     };
 }
 macro_rules! ventry15 {
     () => {
-        Q!("v3")
+        "v3"
     };
 }
 macro_rules! qentry15 {
     () => {
-        Q!("q3")
+        "q3"
     };
 }
 
 macro_rules! vtmp {
     () => {
-        Q!("v16")
+        "v16"
     };
 }
 macro_rules! qtmp {
     () => {
-        Q!("q16")
+        "q16"
     };
 }
 
 macro_rules! vmask {
     () => {
-        Q!("v17")
+        "v17"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_copy_row_from_table_8n_neon.rs
+++ b/graviola/src/low/aarch64/bignum_copy_row_from_table_8n_neon.rs
@@ -20,49 +20,49 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! table {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! height {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! width {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! idx {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 
 macro_rules! i {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! mask {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 
 macro_rules! vmask {
     () => {
-        Q!("v16")
+        "v16"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_demont.rs
+++ b/graviola/src/low/aarch64/bignum_demont.rs
@@ -21,68 +21,68 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 // Outer loop counter
 macro_rules! i {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 // Home for Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 
 macro_rules! h {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! e {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 
@@ -91,27 +91,27 @@ macro_rules! a {
 
 macro_rules! one {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! e1 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! e2 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! e4 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! e8 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_demont_p256.rs
+++ b/graviola/src/low/aarch64/bignum_demont_p256.rs
@@ -47,12 +47,12 @@ macro_rules! montreds {
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 
@@ -60,22 +60,22 @@ macro_rules! x {
 
 macro_rules! d0 {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 
@@ -83,17 +83,17 @@ macro_rules! d3 {
 
 macro_rules! u {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! v {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! w {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_demont_p384.rs
+++ b/graviola/src/low/aarch64/bignum_demont_p384.rs
@@ -62,12 +62,12 @@ macro_rules! montreds {
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 
@@ -75,32 +75,32 @@ macro_rules! x {
 
 macro_rules! d0 {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 
@@ -108,17 +108,17 @@ macro_rules! d5 {
 
 macro_rules! u {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! v {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! w {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_digitsize.rs
+++ b/graviola/src/low/aarch64/bignum_digitsize.rs
@@ -18,27 +18,27 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_eq.rs
+++ b/graviola/src/low/aarch64/bignum_eq.rs
@@ -17,38 +17,38 @@ use crate::low::macros::*;
 
 macro_rules! m {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! n {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 //  We can re-use n for this, not needed when d appears
 macro_rules! d {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_inv_p256.rs
+++ b/graviola/src/low/aarch64/bignum_inv_p256.rs
@@ -24,7 +24,7 @@ use crate::low::macros::*;
 
 macro_rules! N {
     () => {
-        Q!("8")
+        "8"
     };
 }
 
@@ -32,7 +32,7 @@ macro_rules! N {
 
 macro_rules! res {
     () => {
-        Q!("x20")
+        "x20"
     };
 }
 
@@ -40,12 +40,12 @@ macro_rules! res {
 
 macro_rules! i {
     () => {
-        Q!("x21")
+        "x21"
     };
 }
 macro_rules! d {
     () => {
-        Q!("x22")
+        "x22"
     };
 }
 
@@ -53,42 +53,42 @@ macro_rules! d {
 
 macro_rules! m00 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! m01 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! m10 {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! m11 {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 macro_rules! s00 {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 macro_rules! s01 {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! s10 {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 macro_rules! s11 {
     () => {
-        Q!("x17")
+        "x17"
     };
 }
 
@@ -96,12 +96,12 @@ macro_rules! s11 {
 
 macro_rules! car0 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! car1 {
     () => {
-        Q!("x19")
+        "x19"
     };
 }
 
@@ -109,38 +109,38 @@ macro_rules! car1 {
 
 macro_rules! reg0 {
     () => {
-        Q!("x0, #0")
+        "x0, #0"
     };
 }
 macro_rules! reg1 {
     () => {
-        Q!("x1, #0")
+        "x1, #0"
     };
 }
 macro_rules! reg2 {
     () => {
-        Q!("x2, #0")
+        "x2, #0"
     };
 }
 macro_rules! reg3 {
     () => {
-        Q!("x3, #0")
+        "x3, #0"
     };
 }
 macro_rules! reg4 {
     () => {
-        Q!("x4, #0")
+        "x4, #0"
     };
 }
 
 macro_rules! x {
     () => {
-        Q!("x1, #0")
+        "x1, #0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x0, #0")
+        "x0, #0"
     };
 }
 
@@ -148,7 +148,7 @@ macro_rules! z {
 
 macro_rules! f {
     () => {
-        Q!("sp, #0")
+        "sp, #0"
     };
 }
 macro_rules! g { () => { Q!("sp, # (6 * " N!() ")") } }

--- a/graviola/src/low/aarch64/bignum_inv_p384.rs
+++ b/graviola/src/low/aarch64/bignum_inv_p384.rs
@@ -24,7 +24,7 @@ use crate::low::macros::*;
 
 macro_rules! N {
     () => {
-        Q!("8")
+        "8"
     };
 }
 
@@ -32,7 +32,7 @@ macro_rules! N {
 
 macro_rules! res {
     () => {
-        Q!("x20")
+        "x20"
     };
 }
 
@@ -40,12 +40,12 @@ macro_rules! res {
 
 macro_rules! i {
     () => {
-        Q!("x21")
+        "x21"
     };
 }
 macro_rules! d {
     () => {
-        Q!("x22")
+        "x22"
     };
 }
 
@@ -53,42 +53,42 @@ macro_rules! d {
 
 macro_rules! m00 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! m01 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! m10 {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! m11 {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 macro_rules! s00 {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 macro_rules! s01 {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! s10 {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 macro_rules! s11 {
     () => {
-        Q!("x17")
+        "x17"
     };
 }
 
@@ -96,12 +96,12 @@ macro_rules! s11 {
 
 macro_rules! car0 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! car1 {
     () => {
-        Q!("x19")
+        "x19"
     };
 }
 
@@ -109,38 +109,38 @@ macro_rules! car1 {
 
 macro_rules! reg0 {
     () => {
-        Q!("x0, #0")
+        "x0, #0"
     };
 }
 macro_rules! reg1 {
     () => {
-        Q!("x1, #0")
+        "x1, #0"
     };
 }
 macro_rules! reg2 {
     () => {
-        Q!("x2, #0")
+        "x2, #0"
     };
 }
 macro_rules! reg3 {
     () => {
-        Q!("x3, #0")
+        "x3, #0"
     };
 }
 macro_rules! reg4 {
     () => {
-        Q!("x4, #0")
+        "x4, #0"
     };
 }
 
 macro_rules! x {
     () => {
-        Q!("x1, #0")
+        "x1, #0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x0, #0")
+        "x0, #0"
     };
 }
 
@@ -152,7 +152,7 @@ macro_rules! z {
 
 macro_rules! f {
     () => {
-        Q!("sp, #0")
+        "sp, #0"
     };
 }
 macro_rules! g { () => { Q!("sp, # (8 * " N!() ")") } }

--- a/graviola/src/low/aarch64/bignum_mod_n256.rs
+++ b/graviola/src/low/aarch64/bignum_mod_n256.rs
@@ -19,54 +19,54 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 
 macro_rules! n0 {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! n1 {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! n2 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_mod_n384.rs
+++ b/graviola/src/low/aarch64/bignum_mod_n384.rs
@@ -19,74 +19,74 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 
 macro_rules! n0 {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! n1 {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! n2 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! n4 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! n5 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_modadd.rs
+++ b/graviola/src/low/aarch64/bignum_modadd.rs
@@ -17,52 +17,52 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! b {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_modinv.rs
+++ b/graviola/src/low/aarch64/bignum_modinv.rs
@@ -23,7 +23,7 @@ use crate::low::macros::*;
 
 macro_rules! CHUNKSIZE {
     () => {
-        Q!("58")
+        "58"
     };
 }
 
@@ -31,22 +31,22 @@ macro_rules! CHUNKSIZE {
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! b {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! w {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 
@@ -54,12 +54,12 @@ macro_rules! w {
 
 macro_rules! a {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! t {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 
@@ -67,18 +67,18 @@ macro_rules! t {
 
 macro_rules! l {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 
 macro_rules! m {
     () => {
-        Q!("x21")
+        "x21"
     };
 }
 macro_rules! n {
     () => {
-        Q!("x22")
+        "x22"
     };
 }
 
@@ -88,28 +88,28 @@ macro_rules! n {
 
 macro_rules! m_m {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! m_n {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! n_m {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! n_n {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 
 macro_rules! j {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 
@@ -117,17 +117,17 @@ macro_rules! j {
 
 macro_rules! i {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! t1 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! t2 {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 
@@ -136,54 +136,54 @@ macro_rules! t2 {
 
 macro_rules! m_hi {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 macro_rules! n_hi {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 macro_rules! m_lo {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! n_lo {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 
 macro_rules! h1 {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 macro_rules! h2 {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 macro_rules! l1 {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! l2 {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 
 macro_rules! c1 {
     () => {
-        Q!("x17")
+        "x17"
     };
 }
 macro_rules! c2 {
     () => {
-        Q!("x19")
+        "x19"
     };
 }
 
@@ -191,7 +191,7 @@ macro_rules! c2 {
 
 macro_rules! v {
     () => {
-        Q!("x20")
+        "x20"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_modsub.rs
+++ b/graviola/src/low/aarch64/bignum_modsub.rs
@@ -17,52 +17,52 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! b {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_montifier.rs
+++ b/graviola/src/low/aarch64/bignum_montifier.rs
@@ -22,22 +22,22 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! t {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
@@ -46,47 +46,47 @@ macro_rules! t {
 
 macro_rules! i {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! w {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! j {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! h {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! b {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! d {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 
@@ -94,12 +94,12 @@ macro_rules! d {
 
 macro_rules! r {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! q {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_montmul.rs
+++ b/graviola/src/low/aarch64/bignum_montmul.rs
@@ -20,85 +20,85 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 // Top carry for k'th position
 macro_rules! c0 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 // Additional top carry for (k+1)'th position
 macro_rules! c1 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 // Outer loop counter
 macro_rules! i {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 // Home for i'th digit or Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 
 macro_rules! h {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! e {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 
@@ -107,7 +107,7 @@ macro_rules! a {
 
 macro_rules! t {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 
@@ -116,27 +116,27 @@ macro_rules! t {
 
 macro_rules! one {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! e1 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! e2 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! e4 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! e8 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_montredc.rs
+++ b/graviola/src/low/aarch64/bignum_montredc.rs
@@ -23,84 +23,84 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! n {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! p {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 // Outer loop counter
 macro_rules! i {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 // Home for Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 // Top carry for current window
 macro_rules! c {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 
 macro_rules! h {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! e {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 
@@ -109,27 +109,27 @@ macro_rules! a {
 
 macro_rules! one {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! e1 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! e2 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! e4 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! e8 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_montsqr.rs
+++ b/graviola/src/low/aarch64/bignum_montsqr.rs
@@ -20,80 +20,80 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 // Top carry for k'th position
 macro_rules! c0 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 // Additional top carry for (k+1)'th position
 macro_rules! c1 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 // Outer loop counter
 macro_rules! i {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 // Home for i'th digit or Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 
 macro_rules! h {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! e {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 
@@ -102,7 +102,7 @@ macro_rules! a {
 
 macro_rules! t {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 
@@ -111,27 +111,27 @@ macro_rules! t {
 
 macro_rules! one {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! e1 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! e2 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! e4 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! e8 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_mul.rs
+++ b/graviola/src/low/aarch64/bignum_mul.rs
@@ -21,82 +21,82 @@ use crate::low::macros::*;
 
 macro_rules! p {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! n {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! h {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! c {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! k {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! b {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! d {
     () => {
-        Q!("x13")
+        "x13"
     };
 }
 macro_rules! xx {
     () => {
-        Q!("x14")
+        "x14"
     };
 }
 macro_rules! yy {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_mux.rs
+++ b/graviola/src/low/aarch64/bignum_mux.rs
@@ -19,32 +19,32 @@ use crate::low::macros::*;
 
 macro_rules! b {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! k {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_neg_p256.rs
+++ b/graviola/src/low/aarch64/bignum_neg_p256.rs
@@ -16,44 +16,44 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 
 macro_rules! p {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! t {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_neg_p384.rs
+++ b/graviola/src/low/aarch64/bignum_neg_p384.rs
@@ -16,54 +16,54 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 
 macro_rules! p {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! t {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_negmodinv.rs
+++ b/graviola/src/low/aarch64/bignum_negmodinv.rs
@@ -23,53 +23,53 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 
 macro_rules! w {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! h {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! l {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! e {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_optsub.rs
+++ b/graviola/src/low/aarch64/bignum_optsub.rs
@@ -20,47 +20,47 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("x0")
+        "x0"
     };
 }
 macro_rules! z {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! x {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! p {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! m {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! y {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! a {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! b {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_tomont_p256.rs
+++ b/graviola/src/low/aarch64/bignum_tomont_p256.rs
@@ -63,48 +63,48 @@ macro_rules! modstep_p256 {
 
 macro_rules! d0 {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 
 macro_rules! t0 {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 macro_rules! t1 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! t2 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! t3 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 

--- a/graviola/src/low/aarch64/bignum_tomont_p384.rs
+++ b/graviola/src/low/aarch64/bignum_tomont_p384.rs
@@ -62,82 +62,82 @@ macro_rules! modstep_p384 {
 
 macro_rules! d0 {
     () => {
-        Q!("x2")
+        "x2"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("x3")
+        "x3"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("x4")
+        "x4"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("x5")
+        "x5"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("x6")
+        "x6"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("x7")
+        "x7"
     };
 }
 macro_rules! d6 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! t1 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! t2 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! t3 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! n0 {
     () => {
-        Q!("x8")
+        "x8"
     };
 }
 macro_rules! n1 {
     () => {
-        Q!("x9")
+        "x9"
     };
 }
 macro_rules! n2 {
     () => {
-        Q!("x10")
+        "x10"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("x11")
+        "x11"
     };
 }
 macro_rules! n4 {
     () => {
-        Q!("x12")
+        "x12"
     };
 }
 macro_rules! n5 {
     () => {
-        Q!("x1")
+        "x1"
     };
 }
 

--- a/graviola/src/low/aarch64/curve25519_x25519.rs
+++ b/graviola/src/low/aarch64/curve25519_x25519.rs
@@ -27,7 +27,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -36,17 +36,17 @@ macro_rules! NUMSIZE {
 
 macro_rules! res {
     () => {
-        Q!("x23")
+        "x23"
     };
 }
 macro_rules! i {
     () => {
-        Q!("x20")
+        "x20"
     };
 }
 macro_rules! swap {
     () => {
-        Q!("x21")
+        "x21"
     };
 }
 

--- a/graviola/src/low/aarch64/curve25519_x25519base.rs
+++ b/graviola/src/low/aarch64/curve25519_x25519base.rs
@@ -23,7 +23,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -31,7 +31,7 @@ macro_rules! NUMSIZE {
 
 macro_rules! res {
     () => {
-        Q!("x23")
+        "x23"
     };
 }
 
@@ -39,30 +39,30 @@ macro_rules! res {
 
 macro_rules! tab {
     () => {
-        Q!("x19")
+        "x19"
     };
 }
 
 macro_rules! i {
     () => {
-        Q!("x20")
+        "x20"
     };
 }
 
 macro_rules! bias {
     () => {
-        Q!("x21")
+        "x21"
     };
 }
 
 macro_rules! bf {
     () => {
-        Q!("x22")
+        "x22"
     };
 }
 macro_rules! ix {
     () => {
-        Q!("x22")
+        "x22"
     };
 }
 

--- a/graviola/src/low/aarch64/p256_montjadd.rs
+++ b/graviola/src/low/aarch64/p256_montjadd.rs
@@ -22,7 +22,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -30,17 +30,17 @@ macro_rules! NUMSIZE {
 
 macro_rules! input_z {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! input_x {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 macro_rules! input_y {
     () => {
-        Q!("x17")
+        "x17"
     };
 }
 

--- a/graviola/src/low/aarch64/p256_montjdouble.rs
+++ b/graviola/src/low/aarch64/p256_montjdouble.rs
@@ -22,7 +22,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -30,12 +30,12 @@ macro_rules! NUMSIZE {
 
 macro_rules! input_z {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! input_x {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 

--- a/graviola/src/low/aarch64/p256_montjmixadd.rs
+++ b/graviola/src/low/aarch64/p256_montjmixadd.rs
@@ -24,7 +24,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -32,17 +32,17 @@ macro_rules! NUMSIZE {
 
 macro_rules! input_z {
     () => {
-        Q!("x15")
+        "x15"
     };
 }
 macro_rules! input_x {
     () => {
-        Q!("x16")
+        "x16"
     };
 }
 macro_rules! input_y {
     () => {
-        Q!("x17")
+        "x17"
     };
 }
 

--- a/graviola/src/low/aarch64/p384_montjadd.rs
+++ b/graviola/src/low/aarch64/p384_montjadd.rs
@@ -22,7 +22,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("48")
+        "48"
     };
 }
 
@@ -30,17 +30,17 @@ macro_rules! NUMSIZE {
 
 macro_rules! input_z {
     () => {
-        Q!("x24")
+        "x24"
     };
 }
 macro_rules! input_x {
     () => {
-        Q!("x25")
+        "x25"
     };
 }
 macro_rules! input_y {
     () => {
-        Q!("x26")
+        "x26"
     };
 }
 

--- a/graviola/src/low/aarch64/p384_montjdouble.rs
+++ b/graviola/src/low/aarch64/p384_montjdouble.rs
@@ -22,7 +22,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("48")
+        "48"
     };
 }
 
@@ -30,12 +30,12 @@ macro_rules! NUMSIZE {
 
 macro_rules! input_z {
     () => {
-        Q!("x23")
+        "x23"
     };
 }
 macro_rules! input_x {
     () => {
-        Q!("x24")
+        "x24"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_add.rs
+++ b/graviola/src/low/x86_64/bignum_add.rs
@@ -23,48 +23,48 @@ use crate::low::macros::*;
 
 macro_rules! p {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! m {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! y {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_add_p256.rs
+++ b/graviola/src/low/x86_64/bignum_add_p256.rs
@@ -18,60 +18,60 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 
 macro_rules! n1 {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! c {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 
 macro_rules! n1short {
     () => {
-        Q!("r10d")
+        "r10d"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_add_p384.rs
+++ b/graviola/src/low/x86_64/bignum_add_p384.rs
@@ -18,48 +18,48 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 
@@ -67,23 +67,23 @@ macro_rules! d5 {
 
 macro_rules! a {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! c {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("esi")
+        "esi"
     };
 }
 macro_rules! cshort {
     () => {
-        Q!("edx")
+        "edx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_bitsize.rs
+++ b/graviola/src/low/x86_64/bignum_bitsize.rs
@@ -22,32 +22,32 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! i {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! w {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! j {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_cmp_lt.rs
+++ b/graviola/src/low/x86_64/bignum_cmp_lt.rs
@@ -18,38 +18,38 @@ use crate::low::macros::*;
 
 macro_rules! m {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! n {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_copy_row_from_table.rs
+++ b/graviola/src/low/x86_64/bignum_copy_row_from_table.rs
@@ -21,38 +21,38 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! table {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! height {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! width {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! idx {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! j {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_demont.rs
+++ b/graviola/src/low/x86_64/bignum_demont.rs
@@ -22,74 +22,74 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! m {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 
 // General temp, low part of product and mul input
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 // General temp, high part of product (no longer x)
 macro_rules! b {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 // Outer loop counter
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 // Home for Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! e {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 
@@ -97,18 +97,18 @@ macro_rules! n {
 
 macro_rules! t {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! jshort {
     () => {
-        Q!("ebx")
+        "ebx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_demont_p256.rs
+++ b/graviola/src/low/x86_64/bignum_demont_p256.rs
@@ -21,12 +21,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_demont_p384.rs
+++ b/graviola/src/low/x86_64/bignum_demont_p384.rs
@@ -21,12 +21,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_digitsize.rs
+++ b/graviola/src/low/x86_64/bignum_digitsize.rs
@@ -19,27 +19,27 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! i {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! j {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_eq.rs
+++ b/graviola/src/low/x86_64/bignum_eq.rs
@@ -18,33 +18,33 @@ use crate::low::macros::*;
 
 macro_rules! m {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! n {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! c {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 // We can re-use n for this, not needed when d appears
 macro_rules! d {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_inv_p256.rs
+++ b/graviola/src/low/x86_64/bignum_inv_p256.rs
@@ -25,7 +25,7 @@ use crate::low::macros::*;
 
 macro_rules! N {
     () => {
-        Q!("8")
+        "8"
     };
 }
 
@@ -33,7 +33,7 @@ macro_rules! N {
 
 macro_rules! f {
     () => {
-        Q!("rsp + 0")
+        "rsp + 0"
     };
 }
 macro_rules! g { () => { Q!("rsp + (5 * " N!() ")") } }
@@ -58,7 +58,7 @@ macro_rules! NSPACE { () => { Q!("(30 * " N!() ")") } }
 
 macro_rules! F {
     () => {
-        Q!("0")
+        "0"
     };
 }
 macro_rules! G { () => { Q!("(5 * " N!() ")") } }
@@ -68,7 +68,7 @@ macro_rules! MAT { () => { Q!("(24 * " N!() ")") } }
 
 macro_rules! ff {
     () => {
-        Q!("QWORD PTR [rsp]")
+        "QWORD PTR [rsp]"
     };
 }
 macro_rules! gg { () => { Q!("QWORD PTR [rsp + (5 * " N!() ")]") } }

--- a/graviola/src/low/x86_64/bignum_inv_p384.rs
+++ b/graviola/src/low/x86_64/bignum_inv_p384.rs
@@ -25,7 +25,7 @@ use crate::low::macros::*;
 
 macro_rules! N {
     () => {
-        Q!("8")
+        "8"
     };
 }
 
@@ -37,7 +37,7 @@ macro_rules! N {
 
 macro_rules! f {
     () => {
-        Q!("rsp + 0")
+        "rsp + 0"
     };
 }
 macro_rules! g { () => { Q!("rsp + (8 * " N!() ")") } }
@@ -62,7 +62,7 @@ macro_rules! NSPACE { () => { Q!("(42 * " N!() ")") } }
 
 macro_rules! F {
     () => {
-        Q!("0")
+        "0"
     };
 }
 macro_rules! G { () => { Q!("(8 * " N!() ")") } }
@@ -72,7 +72,7 @@ macro_rules! MAT { () => { Q!("(36 * " N!() ")") } }
 
 macro_rules! ff {
     () => {
-        Q!("QWORD PTR [rsp]")
+        "QWORD PTR [rsp]"
     };
 }
 macro_rules! gg { () => { Q!("QWORD PTR [rsp + (8 * " N!() ")]") } }

--- a/graviola/src/low/x86_64/bignum_mod_n256.rs
+++ b/graviola/src/low/x86_64/bignum_mod_n256.rs
@@ -20,55 +20,55 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 
 macro_rules! n0 {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! n1 {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 
 macro_rules! n3short {
     () => {
-        Q!("r11d")
+        "r11d"
     };
 }
 
@@ -76,7 +76,7 @@ macro_rules! n3short {
 
 macro_rules! c {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_mod_n384.rs
+++ b/graviola/src/low/x86_64/bignum_mod_n384.rs
@@ -20,49 +20,49 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! d4 {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! d5 {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 
@@ -70,7 +70,7 @@ macro_rules! a {
 
 macro_rules! c {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_modadd.rs
+++ b/graviola/src/low/x86_64/bignum_modadd.rs
@@ -18,47 +18,47 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! m {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! j {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! c {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_modinv.rs
+++ b/graviola/src/low/x86_64/bignum_modinv.rs
@@ -24,7 +24,7 @@ use crate::low::macros::*;
 
 macro_rules! CHUNKSIZE {
     () => {
-        Q!("58")
+        "58"
     };
 }
 
@@ -33,12 +33,12 @@ macro_rules! CHUNKSIZE {
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! l {
     () => {
-        Q!("r13")
+        "r13"
     };
 }
 
@@ -46,61 +46,61 @@ macro_rules! l {
 
 macro_rules! mat_mm {
     () => {
-        Q!("QWORD PTR [rsp]")
+        "QWORD PTR [rsp]"
     };
 }
 macro_rules! mat_mn {
     () => {
-        Q!("QWORD PTR [rsp + 8]")
+        "QWORD PTR [rsp + 8]"
     };
 }
 macro_rules! mat_nm {
     () => {
-        Q!("QWORD PTR [rsp + 16]")
+        "QWORD PTR [rsp + 16]"
     };
 }
 macro_rules! mat_nn {
     () => {
-        Q!("QWORD PTR [rsp + 24]")
+        "QWORD PTR [rsp + 24]"
     };
 }
 macro_rules! t {
     () => {
-        Q!("QWORD PTR [rsp + 32]")
+        "QWORD PTR [rsp + 32]"
     };
 }
 // Modular inverse
 macro_rules! v {
     () => {
-        Q!("QWORD PTR [rsp + 40]")
+        "QWORD PTR [rsp + 40]"
     };
 }
 // We reconstruct n as m + 8*k as needed
 macro_rules! m {
     () => {
-        Q!("QWORD PTR [rsp + 48]")
+        "QWORD PTR [rsp + 48]"
     };
 }
 macro_rules! w {
     () => {
-        Q!("QWORD PTR [rsp + 56]")
+        "QWORD PTR [rsp + 56]"
     };
 }
 macro_rules! z {
     () => {
-        Q!("QWORD PTR [rsp + 64]")
+        "QWORD PTR [rsp + 64]"
     };
 }
 // Original b pointer, not b the temp
 macro_rules! bm {
     () => {
-        Q!("QWORD PTR [rsp + 72]")
+        "QWORD PTR [rsp + 72]"
     };
 }
 
 macro_rules! STACKVARSIZE {
     () => {
-        Q!("80")
+        "80"
     };
 }
 
@@ -109,12 +109,12 @@ macro_rules! STACKVARSIZE {
 
 macro_rules! p1 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! p2 {
     () => {
-        Q!("r15")
+        "r15"
     };
 }
 
@@ -122,27 +122,27 @@ macro_rules! p2 {
 
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! b {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 macro_rules! c {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! d {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 
@@ -150,32 +150,32 @@ macro_rules! i {
 
 macro_rules! c1 {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! c2 {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! h1 {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! h2 {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! l1 {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 macro_rules! l2 {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -183,22 +183,22 @@ macro_rules! l2 {
 
 macro_rules! m_hi {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! n_hi {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! m_lo {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 macro_rules! n_lo {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -207,53 +207,53 @@ macro_rules! n_lo {
 
 macro_rules! m_m {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! m_n {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! n_m {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! n_n {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! ishort {
     () => {
-        Q!("r9d")
+        "r9d"
     };
 }
 macro_rules! m_mshort {
     () => {
-        Q!("r10d")
+        "r10d"
     };
 }
 macro_rules! m_nshort {
     () => {
-        Q!("r11d")
+        "r11d"
     };
 }
 macro_rules! n_mshort {
     () => {
-        Q!("ecx")
+        "ecx"
     };
 }
 macro_rules! n_nshort {
     () => {
-        Q!("edx")
+        "edx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_modsub.rs
+++ b/graviola/src/low/x86_64/bignum_modsub.rs
@@ -18,47 +18,47 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! m {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! j {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! c {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montifier.rs
+++ b/graviola/src/low/x86_64/bignum_montifier.rs
@@ -23,12 +23,12 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -36,12 +36,12 @@ macro_rules! z {
 
 macro_rules! m {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! t {
     () => {
-        Q!("r13")
+        "r13"
     };
 }
 
@@ -49,56 +49,56 @@ macro_rules! t {
 
 macro_rules! i {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 // Modular inverse; aliased to i, but we never use them together
 macro_rules! w {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 macro_rules! j {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 // Matters that this is RAX for special use in multiplies
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 // Matters that this is RDX for special use in multiplies
 macro_rules! d {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 // Matters that this is RCX as CL=lo(c) is assumed in shifts
 macro_rules! c {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! l {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! b {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 
@@ -106,33 +106,33 @@ macro_rules! n {
 
 macro_rules! q {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! r {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! ishort {
     () => {
-        Q!("ebx")
+        "ebx"
     };
 }
 macro_rules! jshort {
     () => {
-        Q!("ebp")
+        "ebp"
     };
 }
 macro_rules! qshort {
     () => {
-        Q!("r8d")
+        "r8d"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montmul.rs
+++ b/graviola/src/low/x86_64/bignum_montmul.rs
@@ -23,82 +23,82 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! m {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 
 // General temp, low part of product and mul input
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 // General temp, High part of product
 macro_rules! b {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 // Home for i'th digit or Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! e {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r13")
+        "r13"
     };
 }
 macro_rules! c0 {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 macro_rules! c1 {
     () => {
-        Q!("r15")
+        "r15"
     };
 }
 
@@ -109,7 +109,7 @@ macro_rules! c1 {
 
 macro_rules! w {
     () => {
-        Q!("QWORD PTR [rsp]")
+        "QWORD PTR [rsp]"
     };
 }
 
@@ -117,23 +117,23 @@ macro_rules! w {
 
 macro_rules! t1 {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 macro_rules! t2 {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! jshort {
     () => {
-        Q!("ebx")
+        "ebx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montmul_p256.rs
+++ b/graviola/src/low/x86_64/bignum_montmul_p256.rs
@@ -22,12 +22,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -35,7 +35,7 @@ macro_rules! x {
 
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montmul_p384.rs
+++ b/graviola/src/low/x86_64/bignum_montmul_p384.rs
@@ -22,12 +22,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -35,7 +35,7 @@ macro_rules! x {
 
 macro_rules! y {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 
@@ -43,22 +43,22 @@ macro_rules! y {
 
 macro_rules! d {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! u {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! v {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! w {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montredc.rs
+++ b/graviola/src/low/x86_64/bignum_montredc.rs
@@ -26,88 +26,88 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! m {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! p {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 
 // General temp, low part of product and mul input
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 // General temp, High part of product
 macro_rules! b {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("QWORD PTR [rsp]")
+        "QWORD PTR [rsp]"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 // Home for i'th digit or Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! e {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! t {
     () => {
-        Q!("r13")
+        "r13"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 macro_rules! c {
     () => {
-        Q!("r15")
+        "r15"
     };
 }
 
@@ -115,28 +115,28 @@ macro_rules! c {
 
 macro_rules! t1 {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 macro_rules! t2 {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! cshort {
     () => {
-        Q!("r15d")
+        "r15d"
     };
 }
 macro_rules! jshort {
     () => {
-        Q!("ebx")
+        "ebx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montsqr.rs
+++ b/graviola/src/low/x86_64/bignum_montsqr.rs
@@ -23,83 +23,83 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! m {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 
 // General temp, low part of product and mul input
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 // General temp, High part of product
 macro_rules! b {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 // Negated modular inverse
 macro_rules! w {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 // Inner loop counter
 macro_rules! j {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 // Home for i'th digit or Montgomery multiplier
 macro_rules! d {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! e {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r13")
+        "r13"
     };
 }
 macro_rules! c0 {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 macro_rules! c1 {
     () => {
-        Q!("r15")
+        "r15"
     };
 }
 
@@ -107,18 +107,18 @@ macro_rules! c1 {
 
 macro_rules! t2 {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! jshort {
     () => {
-        Q!("ebx")
+        "ebx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montsqr_p256.rs
+++ b/graviola/src/low/x86_64/bignum_montsqr_p256.rs
@@ -21,12 +21,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -34,12 +34,12 @@ macro_rules! x {
 
 macro_rules! zero {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! zeroe {
     () => {
-        Q!("ebp")
+        "ebp"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_montsqr_p384.rs
+++ b/graviola/src/low/x86_64/bignum_montsqr_p384.rs
@@ -21,12 +21,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -34,22 +34,22 @@ macro_rules! x {
 
 macro_rules! d {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! u {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! v {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! w {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 
@@ -57,12 +57,12 @@ macro_rules! w {
 
 macro_rules! zero {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 macro_rules! zeroe {
     () => {
-        Q!("ebp")
+        "ebp"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_mul.rs
+++ b/graviola/src/low/x86_64/bignum_mul.rs
@@ -24,17 +24,17 @@ use crate::low::macros::*;
 
 macro_rules! p {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! n {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 
@@ -42,42 +42,42 @@ macro_rules! n {
 
 macro_rules! c {
     () => {
-        Q!("r15")
+        "r15"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r14")
+        "r14"
     };
 }
 macro_rules! l {
     () => {
-        Q!("r13")
+        "r13"
     };
 }
 macro_rules! x {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! y {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! i {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 macro_rules! k {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! m {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 
@@ -85,12 +85,12 @@ macro_rules! m {
 
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! d {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_mux.rs
+++ b/graviola/src/low/x86_64/bignum_mux.rs
@@ -20,37 +20,37 @@ use crate::low::macros::*;
 
 macro_rules! b {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! k {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! y {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_neg_p256.rs
+++ b/graviola/src/low/x86_64/bignum_neg_p256.rs
@@ -17,61 +17,61 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
 macro_rules! q {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 
 macro_rules! d0 {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! d1 {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! d2 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! d3 {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 
 macro_rules! n1 {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 
 macro_rules! d0short {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! n1short {
     () => {
-        Q!("r10d")
+        "r10d"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_neg_p384.rs
+++ b/graviola/src/low/x86_64/bignum_neg_p384.rs
@@ -17,49 +17,49 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
 macro_rules! n0 {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! n1 {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! n2 {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! n3 {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! n4 {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! q {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 
 macro_rules! n0short {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_negmodinv.rs
+++ b/graviola/src/low/x86_64/bignum_negmodinv.rs
@@ -24,70 +24,70 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 // Moved from initial location to free rdx
 macro_rules! x {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 
 macro_rules! a {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! d {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! i {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 macro_rules! m {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! h {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! w {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 macro_rules! t {
     () => {
-        Q!("r12")
+        "r12"
     };
 }
 macro_rules! e {
     () => {
-        Q!("rbx")
+        "rbx"
     };
 }
 
 macro_rules! ashort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! ishort {
     () => {
-        Q!("r8d")
+        "r8d"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_optsub.rs
+++ b/graviola/src/low/x86_64/bignum_optsub.rs
@@ -21,48 +21,48 @@ use crate::low::macros::*;
 
 macro_rules! k {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! z {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! p {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! y {
     () => {
-        Q!("r8")
+        "r8"
     };
 }
 
 macro_rules! i {
     () => {
-        Q!("r9")
+        "r9"
     };
 }
 macro_rules! b {
     () => {
-        Q!("r10")
+        "r10"
     };
 }
 macro_rules! c {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! a {
     () => {
-        Q!("r11")
+        "r11"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_tomont_p256.rs
+++ b/graviola/src/low/x86_64/bignum_tomont_p256.rs
@@ -18,12 +18,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -31,28 +31,28 @@ macro_rules! x {
 
 macro_rules! d {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! u {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! v {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 
 macro_rules! dshort {
     () => {
-        Q!("eax")
+        "eax"
     };
 }
 macro_rules! ushort {
     () => {
-        Q!("edx")
+        "edx"
     };
 }
 

--- a/graviola/src/low/x86_64/bignum_tomont_p384.rs
+++ b/graviola/src/low/x86_64/bignum_tomont_p384.rs
@@ -18,12 +18,12 @@ use crate::low::macros::*;
 
 macro_rules! z {
     () => {
-        Q!("rdi")
+        "rdi"
     };
 }
 macro_rules! x {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
@@ -31,7 +31,7 @@ macro_rules! x {
 
 macro_rules! zero {
     () => {
-        Q!("rbp")
+        "rbp"
     };
 }
 
@@ -39,33 +39,33 @@ macro_rules! zero {
 
 macro_rules! d {
     () => {
-        Q!("rax")
+        "rax"
     };
 }
 macro_rules! u {
     () => {
-        Q!("rdx")
+        "rdx"
     };
 }
 macro_rules! v {
     () => {
-        Q!("rcx")
+        "rcx"
     };
 }
 macro_rules! w {
     () => {
-        Q!("rsi")
+        "rsi"
     };
 }
 
 macro_rules! vshort {
     () => {
-        Q!("ecx")
+        "ecx"
     };
 }
 macro_rules! wshort {
     () => {
-        Q!("esi")
+        "esi"
     };
 }
 

--- a/graviola/src/low/x86_64/curve25519_x25519.rs
+++ b/graviola/src/low/x86_64/curve25519_x25519.rs
@@ -35,7 +35,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -51,7 +51,7 @@ macro_rules! swap { () => { Q!("QWORD PTR [rsp + 12 * " NUMSIZE!() "+ 16]") } }
 
 macro_rules! resx {
     () => {
-        Q!("rbp + 0")
+        "rbp + 0"
     };
 }
 

--- a/graviola/src/low/x86_64/curve25519_x25519base.rs
+++ b/graviola/src/low/x86_64/curve25519_x25519base.rs
@@ -31,7 +31,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 

--- a/graviola/src/low/x86_64/p256_montjadd.rs
+++ b/graviola/src/low/x86_64/p256_montjadd.rs
@@ -23,7 +23,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -36,7 +36,7 @@ macro_rules! NUMSIZE {
 
 macro_rules! x_1 {
     () => {
-        Q!("rsi + 0")
+        "rsi + 0"
     };
 }
 macro_rules! y_1 { () => { Q!("rsi + " NUMSIZE!()) } }
@@ -44,7 +44,7 @@ macro_rules! z_1 { () => { Q!("rsi + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_2 {
     () => {
-        Q!("rbp + 0")
+        "rbp + 0"
     };
 }
 macro_rules! y_2 { () => { Q!("rbp + " NUMSIZE!()) } }
@@ -52,7 +52,7 @@ macro_rules! z_2 { () => { Q!("rbp + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_3 {
     () => {
-        Q!("rdi + 0")
+        "rdi + 0"
     };
 }
 macro_rules! y_3 { () => { Q!("rdi + " NUMSIZE!()) } }

--- a/graviola/src/low/x86_64/p256_montjdouble.rs
+++ b/graviola/src/low/x86_64/p256_montjdouble.rs
@@ -23,7 +23,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -33,7 +33,7 @@ macro_rules! NUMSIZE {
 
 macro_rules! x_1 {
     () => {
-        Q!("rsi + 0")
+        "rsi + 0"
     };
 }
 macro_rules! y_1 { () => { Q!("rsi + " NUMSIZE!()) } }
@@ -41,7 +41,7 @@ macro_rules! z_1 { () => { Q!("rsi + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_3 {
     () => {
-        Q!("rdi + 0")
+        "rdi + 0"
     };
 }
 macro_rules! y_3 { () => { Q!("rdi + " NUMSIZE!()) } }

--- a/graviola/src/low/x86_64/p256_montjmixadd.rs
+++ b/graviola/src/low/x86_64/p256_montjmixadd.rs
@@ -25,7 +25,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("32")
+        "32"
     };
 }
 
@@ -38,7 +38,7 @@ macro_rules! NUMSIZE {
 
 macro_rules! x_1 {
     () => {
-        Q!("rsi + 0")
+        "rsi + 0"
     };
 }
 macro_rules! y_1 { () => { Q!("rsi + " NUMSIZE!()) } }
@@ -46,14 +46,14 @@ macro_rules! z_1 { () => { Q!("rsi + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_2 {
     () => {
-        Q!("rbp + 0")
+        "rbp + 0"
     };
 }
 macro_rules! y_2 { () => { Q!("rbp + " NUMSIZE!()) } }
 
 macro_rules! x_3 {
     () => {
-        Q!("rdi + 0")
+        "rdi + 0"
     };
 }
 macro_rules! y_3 { () => { Q!("rdi + " NUMSIZE!()) } }

--- a/graviola/src/low/x86_64/p384_montjadd.rs
+++ b/graviola/src/low/x86_64/p384_montjadd.rs
@@ -23,7 +23,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("48")
+        "48"
     };
 }
 
@@ -34,7 +34,7 @@ macro_rules! NUMSIZE {
 
 macro_rules! x_1 {
     () => {
-        Q!("rsi + 0")
+        "rsi + 0"
     };
 }
 macro_rules! y_1 { () => { Q!("rsi + " NUMSIZE!()) } }
@@ -42,7 +42,7 @@ macro_rules! z_1 { () => { Q!("rsi + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_2 {
     () => {
-        Q!("rcx + 0")
+        "rcx + 0"
     };
 }
 macro_rules! y_2 { () => { Q!("rcx + " NUMSIZE!()) } }
@@ -50,7 +50,7 @@ macro_rules! z_2 { () => { Q!("rcx + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_3 {
     () => {
-        Q!("rdi + 0")
+        "rdi + 0"
     };
 }
 macro_rules! y_3 { () => { Q!("rdi + " NUMSIZE!()) } }

--- a/graviola/src/low/x86_64/p384_montjdouble.rs
+++ b/graviola/src/low/x86_64/p384_montjdouble.rs
@@ -23,7 +23,7 @@ use crate::low::macros::*;
 
 macro_rules! NUMSIZE {
     () => {
-        Q!("48")
+        "48"
     };
 }
 
@@ -34,7 +34,7 @@ macro_rules! NUMSIZE {
 
 macro_rules! x_1 {
     () => {
-        Q!("rsi + 0")
+        "rsi + 0"
     };
 }
 macro_rules! y_1 { () => { Q!("rsi + " NUMSIZE!()) } }
@@ -42,7 +42,7 @@ macro_rules! z_1 { () => { Q!("rsi + (2 * " NUMSIZE!() ")") } }
 
 macro_rules! x_3 {
     () => {
-        Q!("rdi + 0")
+        "rdi + 0"
     };
 }
 macro_rules! y_3 { () => { Q!("rdi + " NUMSIZE!()) } }


### PR DESCRIPTION
This is equivalent to `concat!("single string")` -> `"single string"` so we can avoid the Q! expansion.