### PR TITLE
Implement Error for graviola::Error

### DIFF
--- a/graviola/src/error.rs
+++ b/graviola/src/error.rs
@@ -48,3 +48,40 @@ impl From<KeyFormatError> for Error {
         Self::KeyFormatError(kfe)
     }
 }
+
+impl core::fmt::Display for KeyFormatError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnsupportedPkcs8Version => write!(f, "unsupported PKCS#8 version"),
+            Self::MismatchedPkcs8Algorithm => write!(f, "mismatched PKCS#8 algorithm"),
+            Self::MismatchedPkcs8Parameters => write!(f, "mismatched PKCS#8 parameters"),
+            Self::MismatchedSec1Curve => write!(f, "mismatched SEC1 curve"),
+            Self::MismatchedSec1PublicKey => write!(f, "mismatched SEC1 public key"),
+        }
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::WrongLength => write!(f, "some slice was the wrong length"),
+            Self::NotUncompressed => write!(
+                f,
+                "a compressed elliptic curve point encoding was encountered"
+            ),
+            Self::NotOnCurve => write!(f, "a public key was invalid"),
+            Self::OutOfRange => write!(f, "a value was too small or large"),
+            Self::RngFailed => write!(
+                f,
+                "a random number generator returned an error or fixed values"
+            ),
+            Self::BadSignature => write!(f, "presented signature is invalid"),
+            Self::DecryptFailed => write!(f, "presented AEAD tag/aad/ciphertext/nonce was wrong"),
+            Self::Asn1Error(e) => write!(f, "an ASN.1 encoding/decoding error: {e}"),
+            Self::KeyFormatError(e) => write!(f, "a key formatting/validation error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for KeyFormatError {}
+impl std::error::Error for Error {}

--- a/graviola/src/error.rs
+++ b/graviola/src/error.rs
@@ -85,3 +85,75 @@ impl core::fmt::Display for Error {
 
 impl std::error::Error for KeyFormatError {}
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(
+            format!("{}", Error::WrongLength),
+            "some slice was the wrong length"
+        );
+        assert_eq!(
+            format!("{}", Error::NotUncompressed),
+            "a compressed elliptic curve point encoding was encountered"
+        );
+        assert_eq!(format!("{}", Error::NotOnCurve), "a public key was invalid");
+        assert_eq!(
+            format!("{}", Error::OutOfRange),
+            "a value was too small or large"
+        );
+        assert_eq!(
+            format!("{}", Error::RngFailed),
+            "a random number generator returned an error or fixed values"
+        );
+        assert_eq!(
+            format!("{}", Error::BadSignature),
+            "presented signature is invalid"
+        );
+        assert_eq!(
+            format!("{}", Error::DecryptFailed),
+            "presented AEAD tag/aad/ciphertext/nonce was wrong"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::Asn1Error(crate::high::asn1::Error::UnexpectedTag)
+            ),
+            "an ASN.1 encoding/decoding error: unexpected tag"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::KeyFormatError(KeyFormatError::UnsupportedPkcs8Version)
+            ),
+            "a key formatting/validation error: unsupported PKCS#8 version"
+        );
+    }
+
+    #[test]
+    fn test_keyformaterror_display() {
+        assert_eq!(
+            format!("{}", KeyFormatError::UnsupportedPkcs8Version),
+            "unsupported PKCS#8 version"
+        );
+        assert_eq!(
+            format!("{}", KeyFormatError::MismatchedPkcs8Algorithm),
+            "mismatched PKCS#8 algorithm"
+        );
+        assert_eq!(
+            format!("{}", KeyFormatError::MismatchedPkcs8Parameters),
+            "mismatched PKCS#8 parameters"
+        );
+        assert_eq!(
+            format!("{}", KeyFormatError::MismatchedSec1Curve),
+            "mismatched SEC1 curve"
+        );
+        assert_eq!(
+            format!("{}", KeyFormatError::MismatchedSec1PublicKey),
+            "mismatched SEC1 public key"
+        );
+    }
+}

--- a/graviola/src/high/asn1.rs
+++ b/graviola/src/high/asn1.rs
@@ -758,16 +758,16 @@ pub enum Error {
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Error::UnexpectedTag => write!(f, "unexpected tag"),
-            Error::UnexpectedEof => write!(f, "unexpected end of input"),
-            Error::UnexpectedTrailingData => write!(f, "unexpected trailing data"),
-            Error::NonCanonicalEncoding => write!(f, "non-canonical encoding"),
-            Error::UnhandledEnumValue => write!(f, "unhandled enum value"),
-            Error::IntegerOutOfRange => write!(f, "integer out of range"),
-            Error::IllegalNull => write!(f, "illegal null"),
-            Error::UnsupportedLargeObjectId => write!(f, "unsupported large object identifier"),
-            Error::UnsupportedLargeObjectLength => write!(f, "unsupported large object length"),
-            Error::UnhandledBitString => write!(f, "unhandled bit string"),
+            Self::UnexpectedTag => write!(f, "unexpected tag"),
+            Self::UnexpectedEof => write!(f, "unexpected end of input"),
+            Self::UnexpectedTrailingData => write!(f, "unexpected trailing data"),
+            Self::NonCanonicalEncoding => write!(f, "non-canonical encoding"),
+            Self::UnhandledEnumValue => write!(f, "unhandled enum value"),
+            Self::IntegerOutOfRange => write!(f, "integer out of range"),
+            Self::IllegalNull => write!(f, "illegal null"),
+            Self::UnsupportedLargeObjectId => write!(f, "unsupported large object identifier"),
+            Self::UnsupportedLargeObjectLength => write!(f, "unsupported large object length"),
+            Self::UnhandledBitString => write!(f, "unhandled bit string"),
         }
     }
 }

--- a/graviola/src/high/asn1.rs
+++ b/graviola/src/high/asn1.rs
@@ -1027,4 +1027,42 @@ mod tests {
         let mut enc = Encoder::new(&mut buffer);
         assert_eq!(value.encode(&mut enc).unwrap(), expected_len);
     }
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(format!("{}", Error::UnexpectedTag), "unexpected tag");
+        assert_eq!(
+            format!("{}", Error::UnexpectedEof),
+            "unexpected end of input"
+        );
+        assert_eq!(
+            format!("{}", Error::UnexpectedTrailingData),
+            "unexpected trailing data"
+        );
+        assert_eq!(
+            format!("{}", Error::NonCanonicalEncoding),
+            "non-canonical encoding"
+        );
+        assert_eq!(
+            format!("{}", Error::UnhandledEnumValue),
+            "unhandled enum value"
+        );
+        assert_eq!(
+            format!("{}", Error::IntegerOutOfRange),
+            "integer out of range"
+        );
+        assert_eq!(format!("{}", Error::IllegalNull), "illegal null");
+        assert_eq!(
+            format!("{}", Error::UnsupportedLargeObjectId),
+            "unsupported large object identifier"
+        );
+        assert_eq!(
+            format!("{}", Error::UnsupportedLargeObjectLength),
+            "unsupported large object length"
+        );
+        assert_eq!(
+            format!("{}", Error::UnhandledBitString),
+            "unhandled bit string"
+        );
+    }
 }

--- a/graviola/src/high/asn1.rs
+++ b/graviola/src/high/asn1.rs
@@ -755,6 +755,25 @@ pub enum Error {
     UnhandledBitString,
 }
 
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::UnexpectedTag => write!(f, "unexpected tag"),
+            Error::UnexpectedEof => write!(f, "unexpected end of input"),
+            Error::UnexpectedTrailingData => write!(f, "unexpected trailing data"),
+            Error::NonCanonicalEncoding => write!(f, "non-canonical encoding"),
+            Error::UnhandledEnumValue => write!(f, "unhandled enum value"),
+            Error::IntegerOutOfRange => write!(f, "integer out of range"),
+            Error::IllegalNull => write!(f, "illegal null"),
+            Error::UnsupportedLargeObjectId => write!(f, "unsupported large object identifier"),
+            Error::UnsupportedLargeObjectLength => write!(f, "unsupported large object length"),
+            Error::UnhandledBitString => write!(f, "unhandled bit string"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Tag(u8);
 


### PR DESCRIPTION
I saw your talk at Rust Nation about this project and really enjoyed it! While trying it out, the first (and so far only) point of friction is that the `graviola::Error` type doesn't implement `Error`, making it a _bit_ inconvenient to work with.

In case this wasn't a deliberate omission, I thought I'd provide a simple PR. (If not, please feel free to just close this.) The required implementations of `core::fmt::Display` are simply based on the docs for each variant, converted to the standard lowercase, non-punctuated style.

This currently uses `std::error::Error` instead of `core::error::Error` because the latter would mean a `rust-version` bump up to 1.81. Depending on what happens with #57, this could perhaps be gated behind a `std` feature (in order to keep the MSRV), or switch to core and bump the MSRV.