### PR TITLE
Document and check intel adx CPU feature bit requirement

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  VALGRIND_BUG_494162: 1
 
 jobs:
   bench:

--- a/.github/workflows/ctgrind.yml
+++ b/.github/workflows/ctgrind.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  VALGRIND_BUG_494162: 1
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ but there is also a public API for general-purpose use.
 
 - `aarch64` requires `aes`, `sha2`, `pmull`, and `neon` CPU features.
   (This notably excludes Raspberry PI 4 and earlier, but covers Raspberry Pi 5.)
-- `x86_64` requires `aes`, `ssse3` `avx`, `avx2`, `bmi2`, and `pclmulqdq` CPU features.
-  (This is most x86_64 CPUs made since around 2013.)
+- `x86_64` requires `aes`, `ssse3` `avx`, `avx2`, `adx`, `bmi2`, and `pclmulqdq` CPU features.
+  (This is most x86_64 CPUs made since around ~2014.)
 
 ## Acknowledgements and Thanks
 

--- a/graviola/src/low/x86_64/cpu.rs
+++ b/graviola/src/low/x86_64/cpu.rs
@@ -180,16 +180,11 @@ pub(crate) fn verify_cpu_features() {
         "graviola requires bmi1 CPU support"
     );
 
-    // we should have here:
-    //
-    // assert!(
-    //    have_cpu_feature!("adx"),
-    //    "graviola requires adx CPU support"
-    // );
-    //
-    // however, valgrind is buggy (https://bugs.kde.org/show_bug.cgi?id=494162)
-    // -- therefore rely on the expectation that `adx` support is implied by
-    // `bmi1` support.
+    // see this valgrind bug: https://bugs.kde.org/show_bug.cgi?id=494162
+    assert!(
+        have_cpu_feature!("adx") || option_env!("VALGRIND_BUG_494162").is_some(),
+        "graviola requires adx CPU support (rebuild with VALGRIND_BUG_494162 for valgrind compatibility)"
+    );
 
     // assorted intrinsic code
     assert!(


### PR DESCRIPTION
This introduces a `VALGRIND_BUG_494162` build-time environment variable that disables the check for the benefit of valgrind.

fixes #84 