### PR TITLE
Fix performance regression of x86_64 GCM with rustc 1.87

### DIFF
--- a/graviola/src/low/x86_64/ghash.rs
+++ b/graviola/src/low/x86_64/ghash.rs
@@ -112,12 +112,15 @@ impl<'a> Ghash<'a> {
     }
 
     pub(crate) fn into_bytes(self) -> [u8; 16] {
+        // SAFETY: this crate requires the `sse2` and `ssse3` cpu features
+        unsafe { self._into_bytes() }
+    }
+
+    #[target_feature(enable = "sse2,ssse3")]
+    unsafe fn _into_bytes(self) -> [u8; 16] {
         let mut out: i128 = 0;
-        // SAFETY: this crate requires the `avx` cpu feature
-        unsafe {
-            let reverse = _mm_shuffle_epi8(self.current, BYTESWAP);
-            _mm_store_si128(&mut out as *mut i128 as *mut __m128i, reverse)
-        };
+        let reverse = _mm_shuffle_epi8(self.current, BYTESWAP);
+        _mm_store_si128(&mut out as *mut i128 as *mut __m128i, reverse);
         out.to_le_bytes()
     }
 


### PR DESCRIPTION
rustc 1.87 recently broke inlining of intrinsics where the caller has the proper `target_feature`s, but the callee does not. See https://github.com/rust-lang/rust/issues/139029, https://github.com/rust-lang/rust/pull/141309, etc. That looks like (1.86 -> 1.87, main):

```
aes256-gcm/graviola/8KB time:   [2.2043 µs 2.2170 µs 2.2327 µs]
                        thrpt:  [3.4172 GiB/s 3.4413 GiB/s 3.4612 GiB/s]
                 change:
                        time:   [+44.446% +47.398% +50.394%] (p = 0.00 < 0.05)
                        thrpt:  [-33.508% -32.156% -30.770%]
                        Performance has regressed.
```

Which is extremely grim. This PR avoids relying on the previous behaviour, and restores performance with 1.87 (main -> this pr):

```
aes256-gcm/graviola/8KB time:   [1.4685 µs 1.4710 µs 1.4743 µs]
                        thrpt:  [5.1750 GiB/s 5.1866 GiB/s 5.1955 GiB/s]
                 change:
                        time:   [-34.562% -33.443% -32.217%] (p = 0.00 < 0.05)
                        thrpt:  [+47.531% +50.246% +52.818%]
                        Performance has improved.
```