### PR TITLE
Take 2024 edition

### DIFF
--- a/graviola-bench/Cargo.toml
+++ b/graviola-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graviola-bench"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 graviola = { path = "../graviola" }

--- a/graviola/Cargo.toml
+++ b/graviola/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graviola"
 version = "0.2.1"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/ctz/graviola/"
 license = "Apache-2.0 OR ISC OR MIT-0"
 readme = "README.md"

--- a/graviola/src/low/aarch64/aes.rs
+++ b/graviola/src/low/aarch64/aes.rs
@@ -280,30 +280,28 @@ unsafe fn aes128_block(round_keys: &[uint8x16_t; 11], block_inout: &mut [u8]) {
 
 #[target_feature(enable = "aes")]
 #[inline]
-unsafe fn _aes128_block(round_keys: &[uint8x16_t; 11], block: uint8x16_t) -> uint8x16_t {
+fn _aes128_block(round_keys: &[uint8x16_t; 11], block: uint8x16_t) -> uint8x16_t {
     // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let block = vaeseq_u8(block, round_keys[0]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[1]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[2]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[3]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[4]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[5]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[6]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[7]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[8]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[9]);
-        veorq_u8(block, round_keys[10])
-    }
+    let block = vaeseq_u8(block, round_keys[0]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[1]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[2]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[3]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[4]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[5]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[6]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[7]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[8]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[9]);
+    veorq_u8(block, round_keys[10])
 }
 
 macro_rules! round_8 {
@@ -330,7 +328,7 @@ macro_rules! round_8 {
 
 #[target_feature(enable = "aes")]
 #[inline]
-unsafe fn _aes128_8_blocks(
+fn _aes128_8_blocks(
     round_keys: &[uint8x16_t; 11],
     mut b0: uint8x16_t,
     mut b1: uint8x16_t,
@@ -351,87 +349,81 @@ unsafe fn _aes128_8_blocks(
     uint8x16_t,
 ) {
     // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[0]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[1]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[2]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[3]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[4]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[5]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[6]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[7]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[8]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[0]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[1]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[2]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[3]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[4]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[5]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[6]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[7]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[8]);
 
-        let b0 = vaeseq_u8(b0, round_keys[9]);
-        let b1 = vaeseq_u8(b1, round_keys[9]);
-        let b2 = vaeseq_u8(b2, round_keys[9]);
-        let b3 = vaeseq_u8(b3, round_keys[9]);
-        let b4 = vaeseq_u8(b4, round_keys[9]);
-        let b5 = vaeseq_u8(b5, round_keys[9]);
-        let b6 = vaeseq_u8(b6, round_keys[9]);
-        let b7 = vaeseq_u8(b7, round_keys[9]);
-        (
-            veorq_u8(b0, round_keys[10]),
-            veorq_u8(b1, round_keys[10]),
-            veorq_u8(b2, round_keys[10]),
-            veorq_u8(b3, round_keys[10]),
-            veorq_u8(b4, round_keys[10]),
-            veorq_u8(b5, round_keys[10]),
-            veorq_u8(b6, round_keys[10]),
-            veorq_u8(b7, round_keys[10]),
-        )
-    }
+    let b0 = vaeseq_u8(b0, round_keys[9]);
+    let b1 = vaeseq_u8(b1, round_keys[9]);
+    let b2 = vaeseq_u8(b2, round_keys[9]);
+    let b3 = vaeseq_u8(b3, round_keys[9]);
+    let b4 = vaeseq_u8(b4, round_keys[9]);
+    let b5 = vaeseq_u8(b5, round_keys[9]);
+    let b6 = vaeseq_u8(b6, round_keys[9]);
+    let b7 = vaeseq_u8(b7, round_keys[9]);
+    (
+        veorq_u8(b0, round_keys[10]),
+        veorq_u8(b1, round_keys[10]),
+        veorq_u8(b2, round_keys[10]),
+        veorq_u8(b3, round_keys[10]),
+        veorq_u8(b4, round_keys[10]),
+        veorq_u8(b5, round_keys[10]),
+        veorq_u8(b6, round_keys[10]),
+        veorq_u8(b7, round_keys[10]),
+    )
 }
 
 #[target_feature(enable = "aes")]
-unsafe fn aes256_block(round_keys: &[uint8x16_t; 15], block_inout: &mut [u8]) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let block = vld1q_u8(block_inout.as_ptr() as *const _);
-        let block = _aes256_block(round_keys, block);
-        vst1q_u8(block_inout.as_mut_ptr() as *mut _, block);
-    }
-}
-
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn _aes256_block(round_keys: &[uint8x16_t; 15], block: uint8x16_t) -> uint8x16_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let block = vaeseq_u8(block, round_keys[0]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[1]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[2]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[3]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[4]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[5]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[6]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[7]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[8]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[9]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[10]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[11]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[12]);
-        let block = vaesmcq_u8(block);
-        let block = vaeseq_u8(block, round_keys[13]);
-        veorq_u8(block, round_keys[14])
-    }
+fn aes256_block(round_keys: &[uint8x16_t; 15], block_inout: &mut [u8]) {
+    // SAFETY: caller handwaves that `block_inout` is at least 16 bytes(!)
+    let block = unsafe { vld1q_u8(block_inout.as_ptr() as *const _) };
+    let block = _aes256_block(round_keys, block);
+    // SAFETY: caller handwaves that `block_inout` is at least 16 bytes(!)
+    unsafe { vst1q_u8(block_inout.as_mut_ptr() as *mut _, block) };
 }
 
 #[target_feature(enable = "aes")]
 #[inline]
-unsafe fn _aes256_8_blocks(
+fn _aes256_block(round_keys: &[uint8x16_t; 15], block: uint8x16_t) -> uint8x16_t {
+    let block = vaeseq_u8(block, round_keys[0]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[1]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[2]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[3]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[4]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[5]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[6]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[7]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[8]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[9]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[10]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[11]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[12]);
+    let block = vaesmcq_u8(block);
+    let block = vaeseq_u8(block, round_keys[13]);
+    veorq_u8(block, round_keys[14])
+}
+
+#[target_feature(enable = "aes")]
+#[inline]
+fn _aes256_8_blocks(
     round_keys: &[uint8x16_t; 15],
     mut b0: uint8x16_t,
     mut b1: uint8x16_t,
@@ -452,40 +444,38 @@ unsafe fn _aes256_8_blocks(
     uint8x16_t,
 ) {
     // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[0]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[1]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[2]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[3]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[4]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[5]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[6]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[7]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[8]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[9]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[10]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[11]);
-        round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[12]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[0]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[1]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[2]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[3]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[4]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[5]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[6]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[7]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[8]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[9]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[10]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[11]);
+    round_8!(b0, b1, b2, b3, b4, b5, b6, b7, round_keys[12]);
 
-        let b0 = vaeseq_u8(b0, round_keys[13]);
-        let b1 = vaeseq_u8(b1, round_keys[13]);
-        let b2 = vaeseq_u8(b2, round_keys[13]);
-        let b3 = vaeseq_u8(b3, round_keys[13]);
-        let b4 = vaeseq_u8(b4, round_keys[13]);
-        let b5 = vaeseq_u8(b5, round_keys[13]);
-        let b6 = vaeseq_u8(b6, round_keys[13]);
-        let b7 = vaeseq_u8(b7, round_keys[13]);
-        (
-            veorq_u8(b0, round_keys[14]),
-            veorq_u8(b1, round_keys[14]),
-            veorq_u8(b2, round_keys[14]),
-            veorq_u8(b3, round_keys[14]),
-            veorq_u8(b4, round_keys[14]),
-            veorq_u8(b5, round_keys[14]),
-            veorq_u8(b6, round_keys[14]),
-            veorq_u8(b7, round_keys[14]),
-        )
-    }
+    let b0 = vaeseq_u8(b0, round_keys[13]);
+    let b1 = vaeseq_u8(b1, round_keys[13]);
+    let b2 = vaeseq_u8(b2, round_keys[13]);
+    let b3 = vaeseq_u8(b3, round_keys[13]);
+    let b4 = vaeseq_u8(b4, round_keys[13]);
+    let b5 = vaeseq_u8(b5, round_keys[13]);
+    let b6 = vaeseq_u8(b6, round_keys[13]);
+    let b7 = vaeseq_u8(b7, round_keys[13]);
+    (
+        veorq_u8(b0, round_keys[14]),
+        veorq_u8(b1, round_keys[14]),
+        veorq_u8(b2, round_keys[14]),
+        veorq_u8(b3, round_keys[14]),
+        veorq_u8(b4, round_keys[14]),
+        veorq_u8(b5, round_keys[14]),
+        veorq_u8(b6, round_keys[14]),
+        veorq_u8(b7, round_keys[14]),
+    )
 }
 
 #[cfg(test)]

--- a/graviola/src/low/aarch64/bignum_point_select_p256.rs
+++ b/graviola/src/low/aarch64/bignum_point_select_p256.rs
@@ -24,39 +24,44 @@ pub(crate) fn bignum_jac_point_select_p256(z: &mut [u64; 12], table: &[u64], ind
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
+    // SAFETY: u128 and uint32x4_t have same size and meaning
+    let mut acc0: uint32x4_t = unsafe { mem::transmute(0u128) };
+    let mut acc1 = acc0;
+    let mut acc2 = acc0;
+    let mut acc3 = acc0;
+
+    let desired_index = vdupq_n_u32(index as u32);
+    let mut index = vdupq_n_u32(1);
+    let ones = index;
+
+    for point in table.chunks_exact(8) {
+        // SAFETY: `point` is 8 64-bit words, via `chunks_exact`
+        let (row0, row1, row2, row3) = unsafe {
+            (
+                vld1q_u32(point.as_ptr().add(0).cast()),
+                vld1q_u32(point.as_ptr().add(2).cast()),
+                vld1q_u32(point.as_ptr().add(4).cast()),
+                vld1q_u32(point.as_ptr().add(6).cast()),
+            )
+        };
+
+        let mask = vceqq_u32(index, desired_index);
+        index = vaddq_u32(index, ones);
+
+        let row0 = vandq_u32(row0, mask);
+        let row1 = vandq_u32(row1, mask);
+        let row2 = vandq_u32(row2, mask);
+        let row3 = vandq_u32(row3, mask);
+
+        acc0 = veorq_u32(acc0, row0);
+        acc1 = veorq_u32(acc1, row1);
+        acc2 = veorq_u32(acc2, row2);
+        acc3 = veorq_u32(acc3, row3);
+    }
+
+    // SAFETY: `z` has 8 64-bit words and is writable
     unsafe {
-        // SAFETY: u128 and uint32x4_t have same size and meaning
-        let mut acc0: uint32x4_t = mem::transmute(0u128);
-        let mut acc1 = acc0;
-        let mut acc2 = acc0;
-        let mut acc3 = acc0;
-
-        let desired_index = vdupq_n_u32(index as u32);
-        let mut index = vdupq_n_u32(1);
-        let ones = index;
-
-        for point in table.chunks_exact(8) {
-            let row0 = vld1q_u32(point.as_ptr().add(0).cast());
-            let row1 = vld1q_u32(point.as_ptr().add(2).cast());
-            let row2 = vld1q_u32(point.as_ptr().add(4).cast());
-            let row3 = vld1q_u32(point.as_ptr().add(6).cast());
-
-            let mask = vceqq_u32(index, desired_index);
-            index = vaddq_u32(index, ones);
-
-            let row0 = vandq_u32(row0, mask);
-            let row1 = vandq_u32(row1, mask);
-            let row2 = vandq_u32(row2, mask);
-            let row3 = vandq_u32(row3, mask);
-
-            acc0 = veorq_u32(acc0, row0);
-            acc1 = veorq_u32(acc1, row1);
-            acc2 = veorq_u32(acc2, row2);
-            acc3 = veorq_u32(acc3, row3);
-        }
-
         vst1q_u32(z.as_mut_ptr().add(0).cast(), acc0);
         vst1q_u32(z.as_mut_ptr().add(2).cast(), acc1);
         vst1q_u32(z.as_mut_ptr().add(4).cast(), acc2);
@@ -65,46 +70,50 @@ unsafe fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn _select_jac_p256(z: &mut [u64; 12], table: &[u64], index: u8) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _select_jac_p256(z: &mut [u64; 12], table: &[u64], index: u8) {
+    let mut acc0: uint32x4_t = unsafe { mem::transmute(0u128) };
+    let mut acc1 = acc0;
+    let mut acc2 = acc0;
+    let mut acc3 = acc0;
+    let mut acc4 = acc0;
+    let mut acc5 = acc0;
+
+    let desired_index = vdupq_n_u32(index as u32);
+    let mut index = vdupq_n_u32(1);
+    let ones = index;
+
+    for point in table.chunks_exact(12) {
+        // SAFETY: `point` is 12 64-bit words, via `chunks_exact`
+        let (row0, row1, row2, row3, row4, row5) = unsafe {
+            (
+                vld1q_u32(point.as_ptr().add(0).cast()),
+                vld1q_u32(point.as_ptr().add(2).cast()),
+                vld1q_u32(point.as_ptr().add(4).cast()),
+                vld1q_u32(point.as_ptr().add(6).cast()),
+                vld1q_u32(point.as_ptr().add(8).cast()),
+                vld1q_u32(point.as_ptr().add(10).cast()),
+            )
+        };
+
+        let mask = vceqq_u32(index, desired_index);
+        index = vaddq_u32(index, ones);
+
+        let row0 = vandq_u32(row0, mask);
+        let row1 = vandq_u32(row1, mask);
+        let row2 = vandq_u32(row2, mask);
+        let row3 = vandq_u32(row3, mask);
+        let row4 = vandq_u32(row4, mask);
+        let row5 = vandq_u32(row5, mask);
+
+        acc0 = veorq_u32(acc0, row0);
+        acc1 = veorq_u32(acc1, row1);
+        acc2 = veorq_u32(acc2, row2);
+        acc3 = veorq_u32(acc3, row3);
+        acc4 = veorq_u32(acc4, row4);
+        acc5 = veorq_u32(acc5, row5);
+    }
+
     unsafe {
-        let mut acc0: uint32x4_t = mem::transmute(0u128);
-        let mut acc1 = acc0;
-        let mut acc2 = acc0;
-        let mut acc3 = acc0;
-        let mut acc4 = acc0;
-        let mut acc5 = acc0;
-
-        let desired_index = vdupq_n_u32(index as u32);
-        let mut index = vdupq_n_u32(1);
-        let ones = index;
-
-        for point in table.chunks_exact(12) {
-            let row0 = vld1q_u32(point.as_ptr().add(0).cast());
-            let row1 = vld1q_u32(point.as_ptr().add(2).cast());
-            let row2 = vld1q_u32(point.as_ptr().add(4).cast());
-            let row3 = vld1q_u32(point.as_ptr().add(6).cast());
-            let row4 = vld1q_u32(point.as_ptr().add(8).cast());
-            let row5 = vld1q_u32(point.as_ptr().add(10).cast());
-
-            let mask = vceqq_u32(index, desired_index);
-            index = vaddq_u32(index, ones);
-
-            let row0 = vandq_u32(row0, mask);
-            let row1 = vandq_u32(row1, mask);
-            let row2 = vandq_u32(row2, mask);
-            let row3 = vandq_u32(row3, mask);
-            let row4 = vandq_u32(row4, mask);
-            let row5 = vandq_u32(row5, mask);
-
-            acc0 = veorq_u32(acc0, row0);
-            acc1 = veorq_u32(acc1, row1);
-            acc2 = veorq_u32(acc2, row2);
-            acc3 = veorq_u32(acc3, row3);
-            acc4 = veorq_u32(acc4, row4);
-            acc5 = veorq_u32(acc5, row5);
-        }
-
         vst1q_u32(z.as_mut_ptr().add(0).cast(), acc0);
         vst1q_u32(z.as_mut_ptr().add(2).cast(), acc1);
         vst1q_u32(z.as_mut_ptr().add(4).cast(), acc2);

--- a/graviola/src/low/aarch64/bignum_point_select_p384.rs
+++ b/graviola/src/low/aarch64/bignum_point_select_p384.rs
@@ -13,58 +13,64 @@ pub(crate) fn bignum_jac_point_select_p384(z: &mut [u64; 18], table: &[u64], ind
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn _select_jac_p384(z: &mut [u64; 18], table: &[u64], index: u8) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _select_jac_p384(z: &mut [u64; 18], table: &[u64], index: u8) {
+    // SAFETY: uint32x4_t and u128 have the same number and meaning of bits
+    let mut acc0: uint32x4_t = unsafe { mem::transmute(0u128) };
+    let mut acc1 = acc0;
+    let mut acc2 = acc0;
+    let mut acc3 = acc0;
+    let mut acc4 = acc0;
+    let mut acc5 = acc0;
+    let mut acc6 = acc0;
+    let mut acc7 = acc0;
+    let mut acc8 = acc0;
+
+    let desired_index = vdupq_n_u32(index as u32);
+    let mut index = vdupq_n_u32(1);
+    let ones = index;
+
+    for point in table.chunks_exact(18) {
+        // SAFETY: `point` has 18 words and is readable, via `chunks_exact`
+        let (row0, row1, row2, row3, row4, row5, row6, row7, row8) = unsafe {
+            (
+                vld1q_u32(point.as_ptr().add(0).cast()),
+                vld1q_u32(point.as_ptr().add(2).cast()),
+                vld1q_u32(point.as_ptr().add(4).cast()),
+                vld1q_u32(point.as_ptr().add(6).cast()),
+                vld1q_u32(point.as_ptr().add(8).cast()),
+                vld1q_u32(point.as_ptr().add(10).cast()),
+                vld1q_u32(point.as_ptr().add(12).cast()),
+                vld1q_u32(point.as_ptr().add(14).cast()),
+                vld1q_u32(point.as_ptr().add(16).cast()),
+            )
+        };
+
+        let mask = vceqq_u32(index, desired_index);
+        index = vaddq_u32(index, ones);
+
+        let row0 = vandq_u32(row0, mask);
+        let row1 = vandq_u32(row1, mask);
+        let row2 = vandq_u32(row2, mask);
+        let row3 = vandq_u32(row3, mask);
+        let row4 = vandq_u32(row4, mask);
+        let row5 = vandq_u32(row5, mask);
+        let row6 = vandq_u32(row6, mask);
+        let row7 = vandq_u32(row7, mask);
+        let row8 = vandq_u32(row8, mask);
+
+        acc0 = veorq_u32(acc0, row0);
+        acc1 = veorq_u32(acc1, row1);
+        acc2 = veorq_u32(acc2, row2);
+        acc3 = veorq_u32(acc3, row3);
+        acc4 = veorq_u32(acc4, row4);
+        acc5 = veorq_u32(acc5, row5);
+        acc6 = veorq_u32(acc6, row6);
+        acc7 = veorq_u32(acc7, row7);
+        acc8 = veorq_u32(acc8, row8);
+    }
+
+    // SAFETY: `z` can have 18 64-bit words written to it
     unsafe {
-        let mut acc0: uint32x4_t = mem::transmute(0u128);
-        let mut acc1 = acc0;
-        let mut acc2 = acc0;
-        let mut acc3 = acc0;
-        let mut acc4 = acc0;
-        let mut acc5 = acc0;
-        let mut acc6 = acc0;
-        let mut acc7 = acc0;
-        let mut acc8 = acc0;
-
-        let desired_index = vdupq_n_u32(index as u32);
-        let mut index = vdupq_n_u32(1);
-        let ones = index;
-
-        for point in table.chunks_exact(18) {
-            let row0 = vld1q_u32(point.as_ptr().add(0).cast());
-            let row1 = vld1q_u32(point.as_ptr().add(2).cast());
-            let row2 = vld1q_u32(point.as_ptr().add(4).cast());
-            let row3 = vld1q_u32(point.as_ptr().add(6).cast());
-            let row4 = vld1q_u32(point.as_ptr().add(8).cast());
-            let row5 = vld1q_u32(point.as_ptr().add(10).cast());
-            let row6 = vld1q_u32(point.as_ptr().add(12).cast());
-            let row7 = vld1q_u32(point.as_ptr().add(14).cast());
-            let row8 = vld1q_u32(point.as_ptr().add(16).cast());
-
-            let mask = vceqq_u32(index, desired_index);
-            index = vaddq_u32(index, ones);
-
-            let row0 = vandq_u32(row0, mask);
-            let row1 = vandq_u32(row1, mask);
-            let row2 = vandq_u32(row2, mask);
-            let row3 = vandq_u32(row3, mask);
-            let row4 = vandq_u32(row4, mask);
-            let row5 = vandq_u32(row5, mask);
-            let row6 = vandq_u32(row6, mask);
-            let row7 = vandq_u32(row7, mask);
-            let row8 = vandq_u32(row8, mask);
-
-            acc0 = veorq_u32(acc0, row0);
-            acc1 = veorq_u32(acc1, row1);
-            acc2 = veorq_u32(acc2, row2);
-            acc3 = veorq_u32(acc3, row3);
-            acc4 = veorq_u32(acc4, row4);
-            acc5 = veorq_u32(acc5, row5);
-            acc6 = veorq_u32(acc6, row6);
-            acc7 = veorq_u32(acc7, row7);
-            acc8 = veorq_u32(acc8, row8);
-        }
-
         vst1q_u32(z.as_mut_ptr().add(0).cast(), acc0);
         vst1q_u32(z.as_mut_ptr().add(2).cast(), acc1);
         vst1q_u32(z.as_mut_ptr().add(4).cast(), acc2);

--- a/graviola/src/low/aarch64/cpu.rs
+++ b/graviola/src/low/aarch64/cpu.rs
@@ -203,7 +203,7 @@ mod dit {
     }
 
     #[target_feature(enable = "dit")]
-    unsafe fn read() -> u32 {
+    fn read() -> u32 {
         let mut out: u64;
         // SAFETY: `mrs _, DIT` is defined only if `dit` cpu feature is supported
         unsafe {
@@ -218,7 +218,7 @@ mod dit {
     }
 
     #[target_feature(enable = "dit")]
-    unsafe fn write(on: u32) {
+    fn write(on: u32) {
         if on > 0 {
             // SAFETY: `msr DIT, _` is defined only if `dit` cpu feature is supported
             unsafe { core::arch::asm!("msr DIT, #1") }

--- a/graviola/src/low/aarch64/ghash.rs
+++ b/graviola/src/low/aarch64/ghash.rs
@@ -196,18 +196,15 @@ macro_rules! reduce {
 }
 
 #[target_feature(enable = "neon,aes")]
-unsafe fn _mul(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let (mut lo, mut mi, mut hi) = (zero(), zero(), zero());
-        let bx = xor_halves(b);
-        mul!(lo, mi, hi, a, b, bx);
-        reduce!(lo, mi, hi)
-    }
+fn _mul(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+    let (mut lo, mut mi, mut hi) = (zero(), zero(), zero());
+    let bx = xor_halves(b);
+    mul!(lo, mi, hi, a, b, bx);
+    reduce!(lo, mi, hi)
 }
 
 #[target_feature(enable = "neon,aes")]
-unsafe fn _mul8(
+fn _mul8(
     table: &GhashTable,
     a: uint64x2_t,
     b: uint64x2_t,
@@ -218,24 +215,20 @@ unsafe fn _mul8(
     g: uint64x2_t,
     h: uint64x2_t,
 ) -> uint64x2_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let (mut lo, mut mi, mut hi) = (zero(), zero(), zero());
-        mul!(lo, mi, hi, a, table.powers[7], table.powers_xor[7]);
-        mul!(lo, mi, hi, b, table.powers[6], table.powers_xor[6]);
-        mul!(lo, mi, hi, c, table.powers[5], table.powers_xor[5]);
-        mul!(lo, mi, hi, d, table.powers[4], table.powers_xor[4]);
-        mul!(lo, mi, hi, e, table.powers[3], table.powers_xor[3]);
-        mul!(lo, mi, hi, f, table.powers[2], table.powers_xor[2]);
-        mul!(lo, mi, hi, g, table.powers[1], table.powers_xor[1]);
-        mul!(lo, mi, hi, h, table.powers[0], table.powers_xor[0]);
-        reduce!(lo, mi, hi)
-    }
+    let (mut lo, mut mi, mut hi) = (zero(), zero(), zero());
+    mul!(lo, mi, hi, a, table.powers[7], table.powers_xor[7]);
+    mul!(lo, mi, hi, b, table.powers[6], table.powers_xor[6]);
+    mul!(lo, mi, hi, c, table.powers[5], table.powers_xor[5]);
+    mul!(lo, mi, hi, d, table.powers[4], table.powers_xor[4]);
+    mul!(lo, mi, hi, e, table.powers[3], table.powers_xor[3]);
+    mul!(lo, mi, hi, f, table.powers[2], table.powers_xor[2]);
+    mul!(lo, mi, hi, g, table.powers[1], table.powers_xor[1]);
+    mul!(lo, mi, hi, h, table.powers[0], table.powers_xor[0]);
+    reduce!(lo, mi, hi)
 }
 
 #[target_feature(enable = "neon")]
 fn xor_halves(h: uint64x2_t) -> uint64x2_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
     let hx = vextq_u64(h, h, 1);
     veorq_u64(hx, h)
 }
@@ -265,24 +258,22 @@ fn gf128_big_endian(h: uint64x2_t) -> uint64x2_t {
 
 #[inline]
 #[target_feature(enable = "neon,aes")]
-unsafe fn vmull_p64_fix(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let a = vgetq_lane_u64::<0>(a);
-        let b = vgetq_lane_u64::<0>(b);
-        mem::transmute(vmull_p64(a, b))
-    }
+fn vmull_p64_fix(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+    let a = vgetq_lane_u64::<0>(a);
+    let b = vgetq_lane_u64::<0>(b);
+    let p = vmull_p64(a, b);
+    // SAFETY: uint64x2_t and u128 have the same representation
+    unsafe { mem::transmute(p) }
 }
 
 #[inline]
 #[target_feature(enable = "neon,aes")]
-unsafe fn vmull_high_p64_fix(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let a = vgetq_lane_u64::<1>(a);
-        let b = vgetq_lane_u64::<1>(b);
-        mem::transmute(vmull_p64(a, b))
-    }
+fn vmull_high_p64_fix(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+    let a = vgetq_lane_u64::<1>(a);
+    let b = vgetq_lane_u64::<1>(b);
+    let p = vmull_p64(a, b);
+    // SAFETY: uint64x2_t and u128 have the same representation
+    unsafe { mem::transmute(p) }
 }
 
 #[inline]

--- a/graviola/src/low/aarch64/ghash.rs
+++ b/graviola/src/low/aarch64/ghash.rs
@@ -234,36 +234,31 @@ unsafe fn _mul8(
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn xor_halves(h: uint64x2_t) -> uint64x2_t {
+fn xor_halves(h: uint64x2_t) -> uint64x2_t {
     // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let hx = vextq_u64(h, h, 1);
-        veorq_u64(hx, h)
-    }
+    let hx = vextq_u64(h, h, 1);
+    veorq_u64(hx, h)
 }
 
 #[target_feature(enable = "neon")]
-unsafe fn gf128_big_endian(h: uint64x2_t) -> uint64x2_t {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        // takes a raw hash subkey, and arranges that it can
-        // be used in big endian ordering.
-        let t = vreinterpretq_s32_u64(h);
-        let (a, c, d) = (
-            vgetq_lane_s32::<3>(t),
-            vgetq_lane_s32::<1>(t),
-            vgetq_lane_s32::<0>(t),
-        );
-        let t = vsetq_lane_s32(a, t, 3);
-        let t = vsetq_lane_s32(c, t, 2);
-        let t = vsetq_lane_s32(d, t, 1);
-        let t = vsetq_lane_s32(a, t, 0);
+fn gf128_big_endian(h: uint64x2_t) -> uint64x2_t {
+    // takes a raw hash subkey, and arranges that it can
+    // be used in big endian ordering.
+    let t = vreinterpretq_s32_u64(h);
+    let (a, c, d) = (
+        vgetq_lane_s32::<3>(t),
+        vgetq_lane_s32::<1>(t),
+        vgetq_lane_s32::<0>(t),
+    );
+    let t = vsetq_lane_s32(a, t, 3);
+    let t = vsetq_lane_s32(c, t, 2);
+    let t = vsetq_lane_s32(d, t, 1);
+    let t = vsetq_lane_s32(a, t, 0);
 
-        let t = vreinterpretq_u64_s32(vshrq_n_s32(t, 31));
-        let h = vaddq_u64(h, h);
-        let t = vandq_u64(GF128_POLY_CARRY_MASK, t);
-        veorq_u64(h, t)
-    }
+    let t = vreinterpretq_u64_s32(vshrq_n_s32(t, 31));
+    let h = vaddq_u64(h, h);
+    let t = vandq_u64(GF128_POLY_CARRY_MASK, t);
+    veorq_u64(h, t)
 }
 
 // the intrinsics exist, but have the wrong types :(

--- a/graviola/src/low/aarch64/sha256.rs
+++ b/graviola/src/low/aarch64/sha256.rs
@@ -13,7 +13,8 @@ pub(crate) fn sha256_compress_blocks(state: &mut [u32; 8], blocks: &[u8]) {
 
 macro_rules! k {
     ($k:literal) => {
-        vld1q_u32(K.0.as_ptr().add($k * 4))
+        // SAFETY: values for `$k` are compile-time constants
+        unsafe { vld1q_u32(K.0.as_ptr().add($k * 4)) }
     };
 }
 
@@ -36,70 +37,82 @@ macro_rules! round {
 }
 
 #[target_feature(enable = "neon,sha2")]
-unsafe fn sha256(state: &mut [u32; 8], blocks: &[u8]) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn sha256(state: &mut [u32; 8], blocks: &[u8]) {
+    // SAFETY: `state` is readable, and 8 words in length
+    let (mut state0, mut state1) = unsafe {
+        (
+            vld1q_u32(state[0..4].as_ptr()),
+            vld1q_u32(state[4..8].as_ptr()),
+        )
+    };
+
+    let k0 = k!(0);
+    let k1 = k!(1);
+    let k2 = k!(2);
+    let k3 = k!(3);
+    let k4 = k!(4);
+    let k5 = k!(5);
+    let k6 = k!(6);
+    let k7 = k!(7);
+    let k8 = k!(8);
+    let k9 = k!(9);
+    let k10 = k!(10);
+    let k11 = k!(11);
+    let k12 = k!(12);
+    let k13 = k!(13);
+    let k14 = k!(14);
+    let k15 = k!(15);
+
+    for block in blocks.chunks_exact(64) {
+        let state0_prev = state0;
+        let state1_prev = state1;
+
+        // prefetch next block
+        // SAFETY: prefetches don't constitute an access and are not
+        // archtecturally visible.
+        unsafe { cpu::prefetch_ro(block.as_ptr().add(64)) };
+
+        // SAFETY: `block` is 64 bytes long and readable, via `chunks_exact`
+        let (msg0, msg1, msg2, msg3) = unsafe {
+            (
+                vld1q_u32(block[0..].as_ptr() as *const _),
+                vld1q_u32(block[16..].as_ptr() as *const _),
+                vld1q_u32(block[32..].as_ptr() as *const _),
+                vld1q_u32(block[48..].as_ptr() as *const _),
+            )
+        };
+
+        let msg0 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg0)));
+        let msg1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg1)));
+        let msg2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg2)));
+        let msg3 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg3)));
+
+        round!(msg0, msg1, msg2, msg3, state0, state1, k0);
+        round!(msg1, msg2, msg3, msg0, state0, state1, k1);
+        round!(msg2, msg3, msg0, msg1, state0, state1, k2);
+        round!(msg3, msg0, msg1, msg2, state0, state1, k3);
+
+        round!(msg0, msg1, msg2, msg3, state0, state1, k4);
+        round!(msg1, msg2, msg3, msg0, state0, state1, k5);
+        round!(msg2, msg3, msg0, msg1, state0, state1, k6);
+        round!(msg3, msg0, msg1, msg2, state0, state1, k7);
+
+        round!(msg0, msg1, msg2, msg3, state0, state1, k8);
+        round!(msg1, msg2, msg3, msg0, state0, state1, k9);
+        round!(msg2, msg3, msg0, msg1, state0, state1, k10);
+        round!(msg3, msg0, msg1, msg2, state0, state1, k11);
+
+        round!(msg0, state0, state1, k12);
+        round!(msg1, state0, state1, k13);
+        round!(msg2, state0, state1, k14);
+        round!(msg3, state0, state1, k15);
+
+        state0 = vaddq_u32(state0, state0_prev);
+        state1 = vaddq_u32(state1, state1_prev);
+    }
+
+    // SAFETY: `state` is writable, and 8 words in length
     unsafe {
-        let mut state0 = vld1q_u32(state[0..4].as_ptr());
-        let mut state1 = vld1q_u32(state[4..8].as_ptr());
-
-        let k0 = k!(0);
-        let k1 = k!(1);
-        let k2 = k!(2);
-        let k3 = k!(3);
-        let k4 = k!(4);
-        let k5 = k!(5);
-        let k6 = k!(6);
-        let k7 = k!(7);
-        let k8 = k!(8);
-        let k9 = k!(9);
-        let k10 = k!(10);
-        let k11 = k!(11);
-        let k12 = k!(12);
-        let k13 = k!(13);
-        let k14 = k!(14);
-        let k15 = k!(15);
-
-        for block in blocks.chunks_exact(64) {
-            let state0_prev = state0;
-            let state1_prev = state1;
-
-            // prefetch next block
-            cpu::prefetch_ro(block.as_ptr().add(64));
-
-            let msg0 = vld1q_u32(block[0..].as_ptr() as *const _);
-            let msg1 = vld1q_u32(block[16..].as_ptr() as *const _);
-            let msg2 = vld1q_u32(block[32..].as_ptr() as *const _);
-            let msg3 = vld1q_u32(block[48..].as_ptr() as *const _);
-
-            let msg0 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg0)));
-            let msg1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg1)));
-            let msg2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg2)));
-            let msg3 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(msg3)));
-
-            round!(msg0, msg1, msg2, msg3, state0, state1, k0);
-            round!(msg1, msg2, msg3, msg0, state0, state1, k1);
-            round!(msg2, msg3, msg0, msg1, state0, state1, k2);
-            round!(msg3, msg0, msg1, msg2, state0, state1, k3);
-
-            round!(msg0, msg1, msg2, msg3, state0, state1, k4);
-            round!(msg1, msg2, msg3, msg0, state0, state1, k5);
-            round!(msg2, msg3, msg0, msg1, state0, state1, k6);
-            round!(msg3, msg0, msg1, msg2, state0, state1, k7);
-
-            round!(msg0, msg1, msg2, msg3, state0, state1, k8);
-            round!(msg1, msg2, msg3, msg0, state0, state1, k9);
-            round!(msg2, msg3, msg0, msg1, state0, state1, k10);
-            round!(msg3, msg0, msg1, msg2, state0, state1, k11);
-
-            round!(msg0, state0, state1, k12);
-            round!(msg1, state0, state1, k13);
-            round!(msg2, state0, state1, k14);
-            round!(msg3, state0, state1, k15);
-
-            state0 = vaddq_u32(state0, state0_prev);
-            state1 = vaddq_u32(state1, state1_prev);
-        }
-
         vst1q_u32(state[0..4].as_mut_ptr(), state0);
         vst1q_u32(state[4..8].as_mut_ptr(), state1);
     }

--- a/graviola/src/low/x86_64/aes.rs
+++ b/graviola/src/low/x86_64/aes.rs
@@ -52,7 +52,7 @@ impl AesKey {
     }
 
     #[target_feature(enable = "avx512f")]
-    pub(crate) unsafe fn round_keys_512(&self) -> RoundKeys512 {
+    pub(crate) fn round_keys_512(&self) -> RoundKeys512 {
         match self {
             Self::Aes128(AesKey128 {
                 round_keys: [a, b, c, d, e, f, g, h, i, j, k],

--- a/graviola/src/low/x86_64/aes_gcm.rs
+++ b/graviola/src/low/x86_64/aes_gcm.rs
@@ -380,7 +380,7 @@ struct Counter512(__m512i);
 impl Counter512 {
     #[inline]
     #[target_feature(enable = "sse3,ssse3,avx,avx2,avx512f")]
-    unsafe fn new(bytes: &[u8; 16]) -> Self {
+    fn new(bytes: &[u8; 16]) -> Self {
         // SAFETY: `bytes` is a 128-bits and can be loaded from
         Self(unsafe {
             let mut cnt = Counter::new(bytes);
@@ -400,7 +400,7 @@ impl Counter512 {
     #[target_feature(enable = "avx512f")]
     #[must_use]
     #[inline]
-    unsafe fn into_128(self) -> Counter {
+    fn into_128(self) -> Counter {
         Counter(_mm512_extracti32x4_epi32::<0>(self.0))
     }
 
@@ -421,7 +421,7 @@ struct Counter(__m128i);
 impl Counter {
     #[inline]
     #[target_feature(enable = "sse2,sse3,ssse3")]
-    unsafe fn new(bytes: &[u8; 16]) -> Self {
+    fn new(bytes: &[u8; 16]) -> Self {
         // SAFETY: `bytes` is a 128-bit value and can be loaded from
         let c = unsafe { _mm_lddqu_si128(bytes.as_ptr().cast()) };
         let c = _mm_shuffle_epi8(c, BYTESWAP_EPI64);
@@ -433,7 +433,7 @@ impl Counter {
     #[target_feature(enable = "sse2,ssse3")]
     #[must_use]
     #[inline]
-    unsafe fn next(&mut self) -> __m128i {
+    fn next(&mut self) -> __m128i {
         let r = _mm_shuffle_epi8(self.0, BYTESWAP_EPI64);
         self.0 = _mm_add_epi32(self.0, COUNTER_1);
         r

--- a/graviola/src/low/x86_64/bignum_copy_row_from_table_16_avx2.rs
+++ b/graviola/src/low/x86_64/bignum_copy_row_from_table_16_avx2.rs
@@ -17,49 +17,54 @@ pub(crate) fn bignum_copy_row_from_table_16_avx2(
 }
 
 #[target_feature(enable = "avx,avx2")]
-unsafe fn _bignum_copy_row_from_table_16_avx2(z: &mut [u64], table: &[u64], index: u64) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _bignum_copy_row_from_table_16_avx2(z: &mut [u64], table: &[u64], index: u64) {
+    // SAFETY: prefetches do not fault and are not architecturally visible
     unsafe {
-        // SAFETY: prefetches do not fault and are not architecturally visible
         _mm_prefetch(table.as_ptr().cast(), _MM_HINT_T0);
         _mm_prefetch(table.as_ptr().add(16).cast(), _MM_HINT_T0);
+    }
 
-        let mut acc0 = _mm256_setzero_si256();
-        let mut acc1 = _mm256_setzero_si256();
-        let mut acc2 = _mm256_setzero_si256();
-        let mut acc3 = _mm256_setzero_si256();
+    let mut acc0 = _mm256_setzero_si256();
+    let mut acc1 = _mm256_setzero_si256();
+    let mut acc2 = _mm256_setzero_si256();
+    let mut acc3 = _mm256_setzero_si256();
 
-        let desired_index = _mm_set1_epi64x(index as i64);
-        let desired_index = _mm256_setr_m128i(desired_index, desired_index);
+    let desired_index = _mm_set1_epi64x(index as i64);
+    let desired_index = _mm256_setr_m128i(desired_index, desired_index);
 
-        let index = _mm_set1_epi64x(0);
-        let mut index = _mm256_setr_m128i(index, index);
+    let index = _mm_set1_epi64x(0);
+    let mut index = _mm256_setr_m128i(index, index);
 
-        let ones = _mm_set1_epi64x(1);
-        let ones = _mm256_setr_m128i(ones, ones);
+    let ones = _mm_set1_epi64x(1);
+    let ones = _mm256_setr_m128i(ones, ones);
 
-        for row in table.chunks_exact(16) {
-            let mask = _mm256_cmpeq_epi64(index, desired_index);
-            index = _mm256_add_epi64(index, ones);
+    for row in table.chunks_exact(16) {
+        let mask = _mm256_cmpeq_epi64(index, desired_index);
+        index = _mm256_add_epi64(index, ones);
 
-            // SAFETY: `row` is exactly 16 words; `loadu` relaxes 256-bit alignment req.
-            let row0 = _mm256_loadu_si256(row.as_ptr().add(0).cast());
-            let row1 = _mm256_loadu_si256(row.as_ptr().add(4).cast());
-            let row2 = _mm256_loadu_si256(row.as_ptr().add(8).cast());
-            let row3 = _mm256_loadu_si256(row.as_ptr().add(12).cast());
+        // SAFETY: `row` is exactly 16 words; `loadu` relaxes 256-bit alignment req.
+        let (row0, row1, row2, row3) = unsafe {
+            (
+                _mm256_loadu_si256(row.as_ptr().add(0).cast()),
+                _mm256_loadu_si256(row.as_ptr().add(4).cast()),
+                _mm256_loadu_si256(row.as_ptr().add(8).cast()),
+                _mm256_loadu_si256(row.as_ptr().add(12).cast()),
+            )
+        };
 
-            let row0 = _mm256_and_si256(row0, mask);
-            let row1 = _mm256_and_si256(row1, mask);
-            let row2 = _mm256_and_si256(row2, mask);
-            let row3 = _mm256_and_si256(row3, mask);
+        let row0 = _mm256_and_si256(row0, mask);
+        let row1 = _mm256_and_si256(row1, mask);
+        let row2 = _mm256_and_si256(row2, mask);
+        let row3 = _mm256_and_si256(row3, mask);
 
-            acc0 = _mm256_xor_si256(row0, acc0);
-            acc1 = _mm256_xor_si256(row1, acc1);
-            acc2 = _mm256_xor_si256(row2, acc2);
-            acc3 = _mm256_xor_si256(row3, acc3);
-        }
+        acc0 = _mm256_xor_si256(row0, acc0);
+        acc1 = _mm256_xor_si256(row1, acc1);
+        acc2 = _mm256_xor_si256(row2, acc2);
+        acc3 = _mm256_xor_si256(row3, acc3);
+    }
 
-        // SAFETY: `z` is exactly 16 words
+    // SAFETY: `z` is exactly 16 words
+    unsafe {
         _mm256_storeu_si256(z.as_mut_ptr().add(0).cast(), acc0);
         _mm256_storeu_si256(z.as_mut_ptr().add(4).cast(), acc1);
         _mm256_storeu_si256(z.as_mut_ptr().add(8).cast(), acc2);

--- a/graviola/src/low/x86_64/bignum_copy_row_from_table_8n_avx2.rs
+++ b/graviola/src/low/x86_64/bignum_copy_row_from_table_8n_avx2.rs
@@ -19,48 +19,52 @@ pub(crate) fn bignum_copy_row_from_table_8n_avx2(
 }
 
 #[target_feature(enable = "avx,avx2")]
-unsafe fn _bignum_copy_row_from_table_8n_avx2(
-    z: &mut [u64],
-    table: &[u64],
-    width: u64,
-    index: u64,
-) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _bignum_copy_row_from_table_8n_avx2(z: &mut [u64], table: &[u64], width: u64, index: u64) {
+    // SAFETY: prefetches do not fault and are not architecturally visible
     unsafe {
-        // SAFETY: prefetches do not fault and are not architecturally visible
         _mm_prefetch(table.as_ptr().cast(), _MM_HINT_T0);
         _mm_prefetch(table.as_ptr().add(16).cast(), _MM_HINT_T0);
+    }
 
-        z.fill(0);
+    z.fill(0);
 
-        let desired_index = _mm_set1_epi64x(index as i64);
-        let desired_index = _mm256_setr_m128i(desired_index, desired_index);
+    let desired_index = _mm_set1_epi64x(index as i64);
+    let desired_index = _mm256_setr_m128i(desired_index, desired_index);
 
-        let index = _mm_set1_epi64x(0);
-        let mut index = _mm256_setr_m128i(index, index);
+    let index = _mm_set1_epi64x(0);
+    let mut index = _mm256_setr_m128i(index, index);
 
-        let ones = _mm_set1_epi64x(1);
-        let ones = _mm256_setr_m128i(ones, ones);
+    let ones = _mm_set1_epi64x(1);
+    let ones = _mm256_setr_m128i(ones, ones);
 
-        for row in table.chunks_exact(width as usize) {
-            let mask = _mm256_cmpeq_epi64(index, desired_index);
-            index = _mm256_add_epi64(index, ones);
+    for row in table.chunks_exact(width as usize) {
+        let mask = _mm256_cmpeq_epi64(index, desired_index);
+        index = _mm256_add_epi64(index, ones);
 
-            for (i, zz) in z.chunks_exact_mut(8).enumerate() {
-                // SAFETY: `row` is a multiple of 8 words in length
-                let row0 = _mm256_loadu_si256(row.as_ptr().add(i * 8).cast());
-                let row1 = _mm256_loadu_si256(row.as_ptr().add(i * 8 + 4).cast());
+        for (i, zz) in z.chunks_exact_mut(8).enumerate() {
+            // SAFETY: `row` is a multiple of 8 words in length
+            let (row0, row1) = unsafe {
+                (
+                    _mm256_loadu_si256(row.as_ptr().add(i * 8).cast()),
+                    _mm256_loadu_si256(row.as_ptr().add(i * 8 + 4).cast()),
+                )
+            };
 
-                let row0 = _mm256_and_si256(row0, mask);
-                let row1 = _mm256_and_si256(row1, mask);
+            let row0 = _mm256_and_si256(row0, mask);
+            let row1 = _mm256_and_si256(row1, mask);
 
-                // SAFETY: `zz` is exactly 8 words
-                let store0 = _mm256_loadu_si256(zz.as_ptr().add(0).cast());
-                let store1 = _mm256_loadu_si256(zz.as_ptr().add(4).cast());
-                let store0 = _mm256_xor_si256(store0, row0);
-                let store1 = _mm256_xor_si256(store1, row1);
+            // SAFETY: `zz` is exactly 8 words
+            let (store0, store1) = unsafe {
+                (
+                    _mm256_loadu_si256(zz.as_ptr().add(0).cast()),
+                    _mm256_loadu_si256(zz.as_ptr().add(4).cast()),
+                )
+            };
+            let store0 = _mm256_xor_si256(store0, row0);
+            let store1 = _mm256_xor_si256(store1, row1);
 
-                // SAFETY: `zz` is exactly 8 words
+            // SAFETY: `zz` is exactly 8 words and writable
+            unsafe {
                 _mm256_storeu_si256(zz.as_mut_ptr().add(0).cast(), store0);
                 _mm256_storeu_si256(zz.as_mut_ptr().add(4).cast(), store1);
             }

--- a/graviola/src/low/x86_64/bignum_point_select_p256.rs
+++ b/graviola/src/low/x86_64/bignum_point_select_p256.rs
@@ -23,80 +23,94 @@ pub(crate) fn bignum_jac_point_select_p256(z: &mut [u64; 12], table: &[u64], ind
 }
 
 #[target_feature(enable = "avx,avx2")]
-unsafe fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
+    // SAFETY: prefetches do not fault and are not architecturally visible
     unsafe {
-        // SAFETY: prefetches do not fault and are not architecturally visible
         _mm_prefetch(table.as_ptr().cast(), _MM_HINT_T0);
         _mm_prefetch(table.as_ptr().add(16).cast(), _MM_HINT_T0);
+    }
 
-        let mut acc0 = _mm256_setzero_si256();
-        let mut acc1 = _mm256_setzero_si256();
+    let mut acc0 = _mm256_setzero_si256();
+    let mut acc1 = _mm256_setzero_si256();
 
-        let desired_index = _mm_set1_epi32(index as i32);
-        let desired_index = _mm256_setr_m128i(desired_index, desired_index);
+    let desired_index = _mm_set1_epi32(index as i32);
+    let desired_index = _mm256_setr_m128i(desired_index, desired_index);
 
-        let index = _mm_set1_epi32(1);
-        let mut index = _mm256_setr_m128i(index, index);
+    let index = _mm_set1_epi32(1);
+    let mut index = _mm256_setr_m128i(index, index);
 
-        let ones = index;
+    let ones = index;
 
-        for point in table.chunks_exact(8) {
-            let row0 = _mm256_loadu_si256(point.as_ptr().add(0).cast());
-            let row1 = _mm256_loadu_si256(point.as_ptr().add(4).cast());
+    for point in table.chunks_exact(8) {
+        // SAFETY: `point` is 8 words due to `chunks_exact` and readable
+        let (row0, row1) = unsafe {
+            (
+                _mm256_loadu_si256(point.as_ptr().add(0).cast()),
+                _mm256_loadu_si256(point.as_ptr().add(4).cast()),
+            )
+        };
 
-            let mask = _mm256_cmpeq_epi32(index, desired_index);
-            index = _mm256_add_epi32(index, ones);
+        let mask = _mm256_cmpeq_epi32(index, desired_index);
+        index = _mm256_add_epi32(index, ones);
 
-            let row0 = _mm256_and_si256(row0, mask);
-            let row1 = _mm256_and_si256(row1, mask);
+        let row0 = _mm256_and_si256(row0, mask);
+        let row1 = _mm256_and_si256(row1, mask);
 
-            acc0 = _mm256_xor_si256(acc0, row0);
-            acc1 = _mm256_xor_si256(acc1, row1);
-        }
+        acc0 = _mm256_xor_si256(acc0, row0);
+        acc1 = _mm256_xor_si256(acc1, row1);
+    }
 
+    // SAFETY: `z` is 8 words and writable
+    unsafe {
         _mm256_storeu_si256(z.as_mut_ptr().add(0).cast(), acc0);
         _mm256_storeu_si256(z.as_mut_ptr().add(4).cast(), acc1);
     }
 }
 
 #[target_feature(enable = "avx,avx2")]
-unsafe fn _select_jac_p256(z: &mut [u64; 12], table: &[u64], index: u8) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _select_jac_p256(z: &mut [u64; 12], table: &[u64], index: u8) {
+    // SAFETY: prefetches do not fault and are not architecturally visible
     unsafe {
-        // SAFETY: prefetches do not fault and are not architecturally visible
         _mm_prefetch(table.as_ptr().cast(), _MM_HINT_T0);
         _mm_prefetch(table.as_ptr().add(16).cast(), _MM_HINT_T0);
+    }
 
-        let mut acc0 = _mm256_setzero_si256();
-        let mut acc1 = _mm256_setzero_si256();
-        let mut acc2 = _mm256_setzero_si256();
+    let mut acc0 = _mm256_setzero_si256();
+    let mut acc1 = _mm256_setzero_si256();
+    let mut acc2 = _mm256_setzero_si256();
 
-        let desired_index = _mm_set1_epi32(index as i32);
-        let desired_index = _mm256_setr_m128i(desired_index, desired_index);
+    let desired_index = _mm_set1_epi32(index as i32);
+    let desired_index = _mm256_setr_m128i(desired_index, desired_index);
 
-        let index = _mm_set1_epi32(1);
-        let mut index = _mm256_setr_m128i(index, index);
+    let index = _mm_set1_epi32(1);
+    let mut index = _mm256_setr_m128i(index, index);
 
-        let ones = index;
+    let ones = index;
 
-        for point in table.chunks_exact(12) {
-            let row0 = _mm256_loadu_si256(point.as_ptr().add(0).cast());
-            let row1 = _mm256_loadu_si256(point.as_ptr().add(4).cast());
-            let row2 = _mm256_loadu_si256(point.as_ptr().add(8).cast());
+    for point in table.chunks_exact(12) {
+        // SAFETY: `point` is 12 words due to `chunks_exact` and readable
+        let (row0, row1, row2) = unsafe {
+            (
+                _mm256_loadu_si256(point.as_ptr().add(0).cast()),
+                _mm256_loadu_si256(point.as_ptr().add(4).cast()),
+                _mm256_loadu_si256(point.as_ptr().add(8).cast()),
+            )
+        };
 
-            let mask = _mm256_cmpeq_epi32(index, desired_index);
-            index = _mm256_add_epi32(index, ones);
+        let mask = _mm256_cmpeq_epi32(index, desired_index);
+        index = _mm256_add_epi32(index, ones);
 
-            let row0 = _mm256_and_si256(row0, mask);
-            let row1 = _mm256_and_si256(row1, mask);
-            let row2 = _mm256_and_si256(row2, mask);
+        let row0 = _mm256_and_si256(row0, mask);
+        let row1 = _mm256_and_si256(row1, mask);
+        let row2 = _mm256_and_si256(row2, mask);
 
-            acc0 = _mm256_xor_si256(acc0, row0);
-            acc1 = _mm256_xor_si256(acc1, row1);
-            acc2 = _mm256_xor_si256(acc2, row2);
-        }
+        acc0 = _mm256_xor_si256(acc0, row0);
+        acc1 = _mm256_xor_si256(acc1, row1);
+        acc2 = _mm256_xor_si256(acc2, row2);
+    }
 
+    // SAFETY: `z` is 12 words and writable
+    unsafe {
         _mm256_storeu_si256(z.as_mut_ptr().add(0).cast(), acc0);
         _mm256_storeu_si256(z.as_mut_ptr().add(4).cast(), acc1);
         _mm256_storeu_si256(z.as_mut_ptr().add(8).cast(), acc2);

--- a/graviola/src/low/x86_64/bignum_point_select_p384.rs
+++ b/graviola/src/low/x86_64/bignum_point_select_p384.rs
@@ -12,61 +12,69 @@ pub(crate) fn bignum_jac_point_select_p384(z: &mut [u64; 18], table: &[u64], ind
 }
 
 #[target_feature(enable = "avx,avx2")]
-unsafe fn _select_jac_p384(z: &mut [u64; 18], table: &[u64], index: u8) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn _select_jac_p384(z: &mut [u64; 18], table: &[u64], index: u8) {
+    // SAFETY: prefetches do not fault and are not architecturally visible
     unsafe {
         _mm_prefetch(table.as_ptr().cast(), _MM_HINT_T0);
         _mm_prefetch(table.as_ptr().add(16).cast(), _MM_HINT_T0);
+    }
 
-        let mut acc0 = _mm256_setzero_si256();
-        let mut acc1 = _mm256_setzero_si256();
-        let mut acc2 = _mm256_setzero_si256();
-        let mut acc3 = _mm256_setzero_si256();
-        let mut acc4 = _mm256_setzero_si256();
+    let mut acc0 = _mm256_setzero_si256();
+    let mut acc1 = _mm256_setzero_si256();
+    let mut acc2 = _mm256_setzero_si256();
+    let mut acc3 = _mm256_setzero_si256();
+    let mut acc4 = _mm256_setzero_si256();
 
-        let desired_index = _mm_set1_epi32(index as i32);
-        let desired_index = _mm256_setr_m128i(desired_index, desired_index);
+    let desired_index = _mm_set1_epi32(index as i32);
+    let desired_index = _mm256_setr_m128i(desired_index, desired_index);
 
-        let index = _mm_set1_epi32(1);
-        let mut index = _mm256_setr_m128i(index, index);
+    let index = _mm_set1_epi32(1);
+    let mut index = _mm256_setr_m128i(index, index);
 
-        let ones = index;
+    let ones = index;
 
-        for point in table.chunks_exact(18) {
-            let row0 = _mm256_loadu_si256(point.as_ptr().add(0).cast());
-            let row1 = _mm256_loadu_si256(point.as_ptr().add(4).cast());
-            let row2 = _mm256_loadu_si256(point.as_ptr().add(8).cast());
-            let row3 = _mm256_loadu_si256(point.as_ptr().add(12).cast());
+    for point in table.chunks_exact(18) {
+        // SAFETY: `point` is 18 words due to `chunks_exact` and readable.
+        let (row0, row1, row2, row3) = unsafe {
+            (
+                _mm256_loadu_si256(point.as_ptr().add(0).cast()),
+                _mm256_loadu_si256(point.as_ptr().add(4).cast()),
+                _mm256_loadu_si256(point.as_ptr().add(8).cast()),
+                _mm256_loadu_si256(point.as_ptr().add(12).cast()),
+            )
+        };
 
-            let mut tmp = [0u64; 4];
-            tmp[0..2].copy_from_slice(&point[16..18]);
-            let row4 = _mm256_loadu_si256(tmp.as_ptr().cast());
+        let mut tmp = [0u64; 4];
+        tmp[0..2].copy_from_slice(&point[16..18]);
+        // SAFETY: `tmp` is 4 x 64 bit words and readable
+        let row4 = unsafe { _mm256_loadu_si256(tmp.as_ptr().cast()) };
 
-            let mask = _mm256_cmpeq_epi32(index, desired_index);
-            index = _mm256_add_epi32(index, ones);
+        let mask = _mm256_cmpeq_epi32(index, desired_index);
+        index = _mm256_add_epi32(index, ones);
 
-            let row0 = _mm256_and_si256(row0, mask);
-            let row1 = _mm256_and_si256(row1, mask);
-            let row2 = _mm256_and_si256(row2, mask);
-            let row3 = _mm256_and_si256(row3, mask);
-            let row4 = _mm256_and_si256(row4, mask);
+        let row0 = _mm256_and_si256(row0, mask);
+        let row1 = _mm256_and_si256(row1, mask);
+        let row2 = _mm256_and_si256(row2, mask);
+        let row3 = _mm256_and_si256(row3, mask);
+        let row4 = _mm256_and_si256(row4, mask);
 
-            acc0 = _mm256_xor_si256(acc0, row0);
-            acc1 = _mm256_xor_si256(acc1, row1);
-            acc2 = _mm256_xor_si256(acc2, row2);
-            acc3 = _mm256_xor_si256(acc3, row3);
-            acc4 = _mm256_xor_si256(acc4, row4);
-        }
+        acc0 = _mm256_xor_si256(acc0, row0);
+        acc1 = _mm256_xor_si256(acc1, row1);
+        acc2 = _mm256_xor_si256(acc2, row2);
+        acc3 = _mm256_xor_si256(acc3, row3);
+        acc4 = _mm256_xor_si256(acc4, row4);
+    }
 
-        // SAFETY: `z` is 18-words/1152-bits, requiring a partial write of the final 256-bit term
+    // SAFETY: `z` is 18-words/1152-bits, requiring a partial write of the final 256-bit term
+    unsafe {
         _mm256_storeu_si256(z.as_mut_ptr().add(0).cast(), acc0);
         _mm256_storeu_si256(z.as_mut_ptr().add(4).cast(), acc1);
         _mm256_storeu_si256(z.as_mut_ptr().add(8).cast(), acc2);
         _mm256_storeu_si256(z.as_mut_ptr().add(12).cast(), acc3);
-
-        let mut tmp = [0u64; 4];
-        // SAFETY: `tmp` is 256-bits
-        _mm256_storeu_si256(tmp.as_mut_ptr().cast(), acc4);
-        z[16..18].copy_from_slice(&tmp[0..2]);
     }
+
+    let mut tmp = [0u64; 4];
+    // SAFETY: `tmp` is 256-bits and writable
+    unsafe { _mm256_storeu_si256(tmp.as_mut_ptr().cast(), acc4) };
+    z[16..18].copy_from_slice(&tmp[0..2]);
 }

--- a/graviola/src/low/x86_64/chacha20.rs
+++ b/graviola/src/low/x86_64/chacha20.rs
@@ -97,8 +97,8 @@ macro_rules! rotate_left_128 {
 }
 
 #[target_feature(enable = "ssse3,avx2")]
-unsafe fn format_key(key: &[u8; 32], nonce: &[u8; 16]) -> ChaCha20 {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn format_key(key: &[u8; 32], nonce: &[u8; 16]) -> ChaCha20 {
+    // SAFETY: `SIGMA` `key`, and `nonce` are all readable
     unsafe {
         let z07 = _mm256_set_m128i(
             _mm_lddqu_si128(SIGMA.as_ptr().cast()),
@@ -115,170 +115,172 @@ unsafe fn format_key(key: &[u8; 32], nonce: &[u8; 16]) -> ChaCha20 {
 
 /// Computes 8 blocks.  Does _NOT_ handle ragged output.
 #[target_feature(enable = "avx2")]
-unsafe fn core_8x(t07: __m256i, z8f: &mut __m256i, xor_out_512: &mut [u8]) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let t8f = *z8f;
-        *z8f = _mm256_add_epi32(*z8f, _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 8));
+fn core_8x(t07: __m256i, z8f: &mut __m256i, xor_out_512: &mut [u8]) {
+    let t8f = *z8f;
+    *z8f = _mm256_add_epi32(*z8f, _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 8));
 
-        let z03_z03 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 1));
-        let z47_z47 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 0));
-        let z8b_z8b = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 1));
-        let zcf_zcf = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 0));
+    let z03_z03 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 1));
+    let z47_z47 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 0));
+    let z8b_z8b = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 1));
+    let zcf_zcf = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 0));
 
-        let save_z03 = z03_z03;
-        let save_z47 = z47_z47;
-        let save_z8b = z8b_z8b;
-        let save_zcf = zcf_zcf;
+    let save_z03 = z03_z03;
+    let save_z47 = z47_z47;
+    let save_z8b = z8b_z8b;
+    let save_zcf = zcf_zcf;
 
-        let mut z03_z03 = [z03_z03; 4];
-        let mut z47_z47 = [z47_z47; 4];
-        let mut z8b_z8b = [z8b_z8b; 4];
-        let mut zcf_zcf = [zcf_zcf; 4];
+    let mut z03_z03 = [z03_z03; 4];
+    let mut z47_z47 = [z47_z47; 4];
+    let mut z8b_z8b = [z8b_z8b; 4];
+    let mut zcf_zcf = [zcf_zcf; 4];
 
-        zcf_zcf[0] = _mm256_add_epi32(zcf_zcf[0], _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 4));
-        zcf_zcf[1] = _mm256_add_epi32(zcf_zcf[1], _mm256_set_epi32(0, 0, 0, 1, 0, 0, 0, 5));
-        zcf_zcf[2] = _mm256_add_epi32(zcf_zcf[2], _mm256_set_epi32(0, 0, 0, 2, 0, 0, 0, 6));
-        zcf_zcf[3] = _mm256_add_epi32(zcf_zcf[3], _mm256_set_epi32(0, 0, 0, 3, 0, 0, 0, 7));
+    zcf_zcf[0] = _mm256_add_epi32(zcf_zcf[0], _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 4));
+    zcf_zcf[1] = _mm256_add_epi32(zcf_zcf[1], _mm256_set_epi32(0, 0, 0, 1, 0, 0, 0, 5));
+    zcf_zcf[2] = _mm256_add_epi32(zcf_zcf[2], _mm256_set_epi32(0, 0, 0, 2, 0, 0, 0, 6));
+    zcf_zcf[3] = _mm256_add_epi32(zcf_zcf[3], _mm256_set_epi32(0, 0, 0, 3, 0, 0, 0, 7));
 
-        for _ in 0..10 {
-            for i in 0..4 {
-                z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
-            }
-            for i in 0..4 {
-                zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
-            }
-            for z in &mut zcf_zcf {
-                *z = rotate_left!(*z, 16);
-            }
-
-            for i in 0..4 {
-                z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
-            }
-            for i in 0..4 {
-                z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
-            }
-            for z in &mut z47_z47 {
-                *z = rotate_left!(*z, 12);
-            }
-
-            for i in 0..4 {
-                z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
-            }
-            for i in 0..4 {
-                zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
-            }
-            for z in &mut zcf_zcf {
-                *z = rotate_left!(*z, 8);
-            }
-
-            for i in 0..4 {
-                z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
-            }
-            for i in 0..4 {
-                z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
-            }
-            for z in &mut z47_z47 {
-                *z = rotate_left!(*z, 7);
-            }
-
-            for z in &mut z47_z47 {
-                *z = _mm256_shuffle_epi32(*z, 0b00_11_10_01);
-            }
-            for z in &mut z8b_z8b {
-                *z = _mm256_shuffle_epi32(*z, 0b01_00_11_10);
-            }
-            for z in &mut zcf_zcf {
-                *z = _mm256_shuffle_epi32(*z, 0b10_01_00_11);
-            }
-
-            for i in 0..4 {
-                z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
-            }
-            for i in 0..4 {
-                zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
-            }
-            for z in &mut zcf_zcf {
-                *z = rotate_left!(*z, 16);
-            }
-
-            for i in 0..4 {
-                z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
-            }
-            for i in 0..4 {
-                z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
-            }
-            for z in &mut z47_z47 {
-                *z = rotate_left!(*z, 12);
-            }
-
-            for i in 0..4 {
-                z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
-            }
-            for i in 0..4 {
-                zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
-            }
-            for z in &mut zcf_zcf {
-                *z = rotate_left!(*z, 8);
-            }
-
-            for i in 0..4 {
-                z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
-            }
-            for i in 0..4 {
-                z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
-            }
-            for z in &mut z47_z47 {
-                *z = rotate_left!(*z, 7);
-            }
-
-            for z in &mut z47_z47 {
-                *z = _mm256_shuffle_epi32(*z, 0b10_01_00_11);
-            }
-            for z in &mut z8b_z8b {
-                *z = _mm256_shuffle_epi32(*z, 0b01_00_11_10);
-            }
-            for z in &mut zcf_zcf {
-                *z = _mm256_shuffle_epi32(*z, 0b00_11_10_01);
-            }
+    for _ in 0..10 {
+        for i in 0..4 {
+            z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
+        }
+        for i in 0..4 {
+            zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
+        }
+        for z in &mut zcf_zcf {
+            *z = rotate_left!(*z, 16);
         }
 
         for i in 0..4 {
-            z03_z03[i] = _mm256_add_epi32(z03_z03[i], save_z03);
-            z47_z47[i] = _mm256_add_epi32(z47_z47[i], save_z47);
-            z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], save_z8b);
-            zcf_zcf[i] = _mm256_add_epi32(zcf_zcf[i], save_zcf);
+            z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
+        }
+        for i in 0..4 {
+            z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
+        }
+        for z in &mut z47_z47 {
+            *z = rotate_left!(*z, 12);
         }
 
-        // reapply counter adjustments as save_zcf did not include them
-        zcf_zcf[0] = _mm256_add_epi32(zcf_zcf[0], _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 4));
-        zcf_zcf[1] = _mm256_add_epi32(zcf_zcf[1], _mm256_set_epi32(0, 0, 0, 1, 0, 0, 0, 5));
-        zcf_zcf[2] = _mm256_add_epi32(zcf_zcf[2], _mm256_set_epi32(0, 0, 0, 2, 0, 0, 0, 6));
-        zcf_zcf[3] = _mm256_add_epi32(zcf_zcf[3], _mm256_set_epi32(0, 0, 0, 3, 0, 0, 0, 7));
+        for i in 0..4 {
+            z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
+        }
+        for i in 0..4 {
+            zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
+        }
+        for z in &mut zcf_zcf {
+            *z = rotate_left!(*z, 8);
+        }
 
-        // our eight output keystream blocks
-        let a0 = _mm256_permute2x128_si256(z03_z03[0], z47_z47[0], 0b0011_0001);
-        let a1 = _mm256_permute2x128_si256(z8b_z8b[0], zcf_zcf[0], 0b0011_0001);
-        let b0 = _mm256_permute2x128_si256(z03_z03[1], z47_z47[1], 0b0011_0001);
-        let b1 = _mm256_permute2x128_si256(z8b_z8b[1], zcf_zcf[1], 0b0011_0001);
+        for i in 0..4 {
+            z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
+        }
+        for i in 0..4 {
+            z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
+        }
+        for z in &mut z47_z47 {
+            *z = rotate_left!(*z, 7);
+        }
 
-        let c0 = _mm256_permute2x128_si256(z03_z03[2], z47_z47[2], 0b0011_0001);
-        let c1 = _mm256_permute2x128_si256(z8b_z8b[2], zcf_zcf[2], 0b0011_0001);
-        let d0 = _mm256_permute2x128_si256(z03_z03[3], z47_z47[3], 0b0011_0001);
-        let d1 = _mm256_permute2x128_si256(z8b_z8b[3], zcf_zcf[3], 0b0011_0001);
+        for z in &mut z47_z47 {
+            *z = _mm256_shuffle_epi32(*z, 0b00_11_10_01);
+        }
+        for z in &mut z8b_z8b {
+            *z = _mm256_shuffle_epi32(*z, 0b01_00_11_10);
+        }
+        for z in &mut zcf_zcf {
+            *z = _mm256_shuffle_epi32(*z, 0b10_01_00_11);
+        }
 
-        let e0 = _mm256_permute2x128_si256(z03_z03[0], z47_z47[0], 0b0010_0000);
-        let e1 = _mm256_permute2x128_si256(z8b_z8b[0], zcf_zcf[0], 0b0010_0000);
-        let f0 = _mm256_permute2x128_si256(z03_z03[1], z47_z47[1], 0b0010_0000);
-        let f1 = _mm256_permute2x128_si256(z8b_z8b[1], zcf_zcf[1], 0b0010_0000);
+        for i in 0..4 {
+            z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
+        }
+        for i in 0..4 {
+            zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
+        }
+        for z in &mut zcf_zcf {
+            *z = rotate_left!(*z, 16);
+        }
 
-        let g0 = _mm256_permute2x128_si256(z03_z03[2], z47_z47[2], 0b0010_0000);
-        let g1 = _mm256_permute2x128_si256(z8b_z8b[2], zcf_zcf[2], 0b0010_0000);
-        let h0 = _mm256_permute2x128_si256(z03_z03[3], z47_z47[3], 0b0010_0000);
-        let h1 = _mm256_permute2x128_si256(z8b_z8b[3], zcf_zcf[3], 0b0010_0000);
+        for i in 0..4 {
+            z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
+        }
+        for i in 0..4 {
+            z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
+        }
+        for z in &mut z47_z47 {
+            *z = rotate_left!(*z, 12);
+        }
 
-        let ptr: *mut __m256i = xor_out_512.as_mut_ptr().cast();
+        for i in 0..4 {
+            z03_z03[i] = _mm256_add_epi32(z03_z03[i], z47_z47[i]);
+        }
+        for i in 0..4 {
+            zcf_zcf[i] = _mm256_xor_si256(zcf_zcf[i], z03_z03[i]);
+        }
+        for z in &mut zcf_zcf {
+            *z = rotate_left!(*z, 8);
+        }
 
+        for i in 0..4 {
+            z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], zcf_zcf[i]);
+        }
+        for i in 0..4 {
+            z47_z47[i] = _mm256_xor_si256(z47_z47[i], z8b_z8b[i]);
+        }
+        for z in &mut z47_z47 {
+            *z = rotate_left!(*z, 7);
+        }
+
+        for z in &mut z47_z47 {
+            *z = _mm256_shuffle_epi32(*z, 0b10_01_00_11);
+        }
+        for z in &mut z8b_z8b {
+            *z = _mm256_shuffle_epi32(*z, 0b01_00_11_10);
+        }
+        for z in &mut zcf_zcf {
+            *z = _mm256_shuffle_epi32(*z, 0b00_11_10_01);
+        }
+    }
+
+    for i in 0..4 {
+        z03_z03[i] = _mm256_add_epi32(z03_z03[i], save_z03);
+        z47_z47[i] = _mm256_add_epi32(z47_z47[i], save_z47);
+        z8b_z8b[i] = _mm256_add_epi32(z8b_z8b[i], save_z8b);
+        zcf_zcf[i] = _mm256_add_epi32(zcf_zcf[i], save_zcf);
+    }
+
+    // reapply counter adjustments as save_zcf did not include them
+    zcf_zcf[0] = _mm256_add_epi32(zcf_zcf[0], _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 4));
+    zcf_zcf[1] = _mm256_add_epi32(zcf_zcf[1], _mm256_set_epi32(0, 0, 0, 1, 0, 0, 0, 5));
+    zcf_zcf[2] = _mm256_add_epi32(zcf_zcf[2], _mm256_set_epi32(0, 0, 0, 2, 0, 0, 0, 6));
+    zcf_zcf[3] = _mm256_add_epi32(zcf_zcf[3], _mm256_set_epi32(0, 0, 0, 3, 0, 0, 0, 7));
+
+    // our eight output keystream blocks
+    let a0 = _mm256_permute2x128_si256(z03_z03[0], z47_z47[0], 0b0011_0001);
+    let a1 = _mm256_permute2x128_si256(z8b_z8b[0], zcf_zcf[0], 0b0011_0001);
+    let b0 = _mm256_permute2x128_si256(z03_z03[1], z47_z47[1], 0b0011_0001);
+    let b1 = _mm256_permute2x128_si256(z8b_z8b[1], zcf_zcf[1], 0b0011_0001);
+
+    let c0 = _mm256_permute2x128_si256(z03_z03[2], z47_z47[2], 0b0011_0001);
+    let c1 = _mm256_permute2x128_si256(z8b_z8b[2], zcf_zcf[2], 0b0011_0001);
+    let d0 = _mm256_permute2x128_si256(z03_z03[3], z47_z47[3], 0b0011_0001);
+    let d1 = _mm256_permute2x128_si256(z8b_z8b[3], zcf_zcf[3], 0b0011_0001);
+
+    let e0 = _mm256_permute2x128_si256(z03_z03[0], z47_z47[0], 0b0010_0000);
+    let e1 = _mm256_permute2x128_si256(z8b_z8b[0], zcf_zcf[0], 0b0010_0000);
+    let f0 = _mm256_permute2x128_si256(z03_z03[1], z47_z47[1], 0b0010_0000);
+    let f1 = _mm256_permute2x128_si256(z8b_z8b[1], zcf_zcf[1], 0b0010_0000);
+
+    let g0 = _mm256_permute2x128_si256(z03_z03[2], z47_z47[2], 0b0010_0000);
+    let g1 = _mm256_permute2x128_si256(z8b_z8b[2], zcf_zcf[2], 0b0010_0000);
+    let h0 = _mm256_permute2x128_si256(z03_z03[3], z47_z47[3], 0b0010_0000);
+    let h1 = _mm256_permute2x128_si256(z8b_z8b[3], zcf_zcf[3], 0b0010_0000);
+
+    let ptr: *mut __m256i = xor_out_512.as_mut_ptr().cast();
+
+    // SAFETY: `xor_out_512` is 512 bytes due to chunking in caller. Observe that
+    // `ptr` is unaligned which is allowed as we only use it here with unaligned
+    // stores/loads.
+    unsafe {
         _mm256_storeu_si256(
             ptr.add(0),
             _mm256_xor_si256(_mm256_loadu_si256(ptr.add(0)), a0),
@@ -356,80 +358,80 @@ unsafe fn core_8x(t07: __m256i, z8f: &mut __m256i, xor_out_512: &mut [u8]) {
 /// Computes 2 blocks, but also handles ragged output (ie, xor_out may
 /// be 0..64 bytes).
 #[target_feature(enable = "avx2")]
-unsafe fn core_2x(t07: __m256i, z8f: &mut __m256i, xor_out: &mut [u8]) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let t8f = *z8f;
-        let blocks_used = if xor_out.len() > 32 { 2 } else { 1 };
-        *z8f = _mm256_add_epi32(*z8f, _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, blocks_used));
+fn core_2x(t07: __m256i, z8f: &mut __m256i, xor_out: &mut [u8]) {
+    let t8f = *z8f;
+    let blocks_used = if xor_out.len() > 32 { 2 } else { 1 };
+    *z8f = _mm256_add_epi32(*z8f, _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, blocks_used));
 
-        let mut z03_z03 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 1));
-        let mut z47_z47 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 0));
-        let mut z8b_z8b = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 1));
-        let mut zcf_zcf = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 0));
+    let mut z03_z03 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 1));
+    let mut z47_z47 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t07, 0));
+    let mut z8b_z8b = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 1));
+    let mut zcf_zcf = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(t8f, 0));
 
-        // we will calculate two blocks, so increment the counter of the second block
-        zcf_zcf = _mm256_add_epi32(zcf_zcf, _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 1));
-        let save_z03 = z03_z03;
-        let save_z47 = z47_z47;
-        let save_z8b = z8b_z8b;
-        let save_zcf = zcf_zcf;
+    // we will calculate two blocks, so increment the counter of the second block
+    zcf_zcf = _mm256_add_epi32(zcf_zcf, _mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, 1));
+    let save_z03 = z03_z03;
+    let save_z47 = z47_z47;
+    let save_z8b = z8b_z8b;
+    let save_zcf = zcf_zcf;
 
-        for _ in 0..10 {
-            z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
-            zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
-            zcf_zcf = rotate_left!(zcf_zcf, 16);
+    for _ in 0..10 {
+        z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
+        zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
+        zcf_zcf = rotate_left!(zcf_zcf, 16);
 
-            z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
-            z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
-            z47_z47 = rotate_left!(z47_z47, 12);
+        z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
+        z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
+        z47_z47 = rotate_left!(z47_z47, 12);
 
-            z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
-            zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
-            zcf_zcf = rotate_left!(zcf_zcf, 8);
+        z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
+        zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
+        zcf_zcf = rotate_left!(zcf_zcf, 8);
 
-            z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
-            z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
-            z47_z47 = rotate_left!(z47_z47, 7);
+        z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
+        z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
+        z47_z47 = rotate_left!(z47_z47, 7);
 
-            z47_z47 = _mm256_shuffle_epi32(z47_z47, 0b00_11_10_01);
-            z8b_z8b = _mm256_shuffle_epi32(z8b_z8b, 0b01_00_11_10);
-            zcf_zcf = _mm256_shuffle_epi32(zcf_zcf, 0b10_01_00_11);
+        z47_z47 = _mm256_shuffle_epi32(z47_z47, 0b00_11_10_01);
+        z8b_z8b = _mm256_shuffle_epi32(z8b_z8b, 0b01_00_11_10);
+        zcf_zcf = _mm256_shuffle_epi32(zcf_zcf, 0b10_01_00_11);
 
-            z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
-            zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
-            zcf_zcf = rotate_left!(zcf_zcf, 16);
+        z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
+        zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
+        zcf_zcf = rotate_left!(zcf_zcf, 16);
 
-            z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
-            z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
-            z47_z47 = rotate_left!(z47_z47, 12);
+        z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
+        z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
+        z47_z47 = rotate_left!(z47_z47, 12);
 
-            z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
-            zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
-            zcf_zcf = rotate_left!(zcf_zcf, 8);
+        z03_z03 = _mm256_add_epi32(z03_z03, z47_z47);
+        zcf_zcf = _mm256_xor_si256(zcf_zcf, z03_z03);
+        zcf_zcf = rotate_left!(zcf_zcf, 8);
 
-            z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
-            z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
-            z47_z47 = rotate_left!(z47_z47, 7);
+        z8b_z8b = _mm256_add_epi32(z8b_z8b, zcf_zcf);
+        z47_z47 = _mm256_xor_si256(z47_z47, z8b_z8b);
+        z47_z47 = rotate_left!(z47_z47, 7);
 
-            z47_z47 = _mm256_shuffle_epi32(z47_z47, 0b10_01_00_11);
-            z8b_z8b = _mm256_shuffle_epi32(z8b_z8b, 0b01_00_11_10);
-            zcf_zcf = _mm256_shuffle_epi32(zcf_zcf, 0b00_11_10_01);
-        }
+        z47_z47 = _mm256_shuffle_epi32(z47_z47, 0b10_01_00_11);
+        z8b_z8b = _mm256_shuffle_epi32(z8b_z8b, 0b01_00_11_10);
+        zcf_zcf = _mm256_shuffle_epi32(zcf_zcf, 0b00_11_10_01);
+    }
 
-        let z03_z03 = _mm256_add_epi32(z03_z03, save_z03);
-        let z47_z47 = _mm256_add_epi32(z47_z47, save_z47);
-        let z8b_z8b = _mm256_add_epi32(z8b_z8b, save_z8b);
-        let zcf_zcf = _mm256_add_epi32(zcf_zcf, save_zcf);
+    let z03_z03 = _mm256_add_epi32(z03_z03, save_z03);
+    let z47_z47 = _mm256_add_epi32(z47_z47, save_z47);
+    let z8b_z8b = _mm256_add_epi32(z8b_z8b, save_z8b);
+    let zcf_zcf = _mm256_add_epi32(zcf_zcf, save_zcf);
 
-        let a0 = _mm256_permute2x128_si256(z03_z03, z47_z47, 0b0011_0001);
-        let a1 = _mm256_permute2x128_si256(z8b_z8b, zcf_zcf, 0b0011_0001);
-        let b0 = _mm256_permute2x128_si256(z03_z03, z47_z47, 0b0010_0000);
-        let b1 = _mm256_permute2x128_si256(z8b_z8b, zcf_zcf, 0b0010_0000);
+    let a0 = _mm256_permute2x128_si256(z03_z03, z47_z47, 0b0011_0001);
+    let a1 = _mm256_permute2x128_si256(z8b_z8b, zcf_zcf, 0b0011_0001);
+    let b0 = _mm256_permute2x128_si256(z03_z03, z47_z47, 0b0010_0000);
+    let b1 = _mm256_permute2x128_si256(z8b_z8b, zcf_zcf, 0b0010_0000);
 
-        let ptr: *mut __m256i = xor_out.as_mut_ptr().cast();
+    let ptr: *mut __m256i = xor_out.as_mut_ptr().cast();
 
-        if xor_out.len() == 128 {
+    if xor_out.len() == 128 {
+        // SAFETY: `ptr` is 128 bytes, ie 4 x 256-bit ymm registers
+        unsafe {
             let ia0 = _mm256_loadu_si256(ptr.add(0));
             let ia1 = _mm256_loadu_si256(ptr.add(1));
             let ib0 = _mm256_loadu_si256(ptr.add(2));
@@ -439,84 +441,96 @@ unsafe fn core_2x(t07: __m256i, z8f: &mut __m256i, xor_out: &mut [u8]) {
             _mm256_storeu_si256(ptr.add(1), _mm256_xor_si256(a1, ia1));
             _mm256_storeu_si256(ptr.add(2), _mm256_xor_si256(b0, ib0));
             _mm256_storeu_si256(ptr.add(3), _mm256_xor_si256(b1, ib1));
-        } else if xor_out.len() == 32 {
+        }
+    } else if xor_out.len() == 32 {
+        // SAFETY: `ptr` is 32 bytes, ie one 256-bit ymm register
+        unsafe {
             let ia0 = _mm256_loadu_si256(ptr.add(0));
             _mm256_storeu_si256(ptr.add(0), _mm256_xor_si256(a0, ia0));
-        } else {
-            // slow path
-            let mut ks = [0u8; 128];
+        }
+    } else {
+        // slow path
+        let mut ks = [0u8; 128];
 
+        // SAFETY: `ks` is 128 bytes and writable.
+        unsafe {
             _mm256_storeu_si256(ks[0..32].as_mut_ptr().cast(), a0);
             _mm256_storeu_si256(ks[32..64].as_mut_ptr().cast(), a1);
             _mm256_storeu_si256(ks[64..96].as_mut_ptr().cast(), b0);
             _mm256_storeu_si256(ks[96..128].as_mut_ptr().cast(), b1);
+        }
 
-            for (o, k) in xor_out.iter_mut().zip(ks.iter()) {
-                *o ^= *k;
-            }
+        for (o, k) in xor_out.iter_mut().zip(ks.iter()) {
+            *o ^= *k;
         }
     }
 }
 
 #[target_feature(enable = "ssse3,avx2")]
-unsafe fn hchacha(key: &[u8; 32], nonce: &[u8; 24]) -> ChaCha20 {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let mut z03 = _mm_lddqu_si128(SIGMA.as_ptr().cast());
-        let mut z47 = _mm_lddqu_si128(key[0..16].as_ptr().cast());
-        let mut z8b = _mm_lddqu_si128(key[16..32].as_ptr().cast());
-        let mut zcf = _mm_lddqu_si128(nonce[0..16].as_ptr().cast());
+fn hchacha(key: &[u8; 32], nonce: &[u8; 24]) -> ChaCha20 {
+    // SAFETY: `SIGMA`, `key` and `nonce` are all readable
+    let (mut z03, mut z47, mut z8b, mut zcf) = unsafe {
+        (
+            _mm_lddqu_si128(SIGMA.as_ptr().cast()),
+            _mm_lddqu_si128(key[0..16].as_ptr().cast()),
+            _mm_lddqu_si128(key[16..32].as_ptr().cast()),
+            _mm_lddqu_si128(nonce[0..16].as_ptr().cast()),
+        )
+    };
 
-        for _ in 0..10 {
-            z03 = _mm_add_epi32(z03, z47);
-            zcf = _mm_xor_si128(zcf, z03);
-            zcf = rotate_left_128!(zcf, 16);
+    for _ in 0..10 {
+        z03 = _mm_add_epi32(z03, z47);
+        zcf = _mm_xor_si128(zcf, z03);
+        zcf = rotate_left_128!(zcf, 16);
 
-            z8b = _mm_add_epi32(z8b, zcf);
-            z47 = _mm_xor_si128(z47, z8b);
-            z47 = rotate_left_128!(z47, 12);
+        z8b = _mm_add_epi32(z8b, zcf);
+        z47 = _mm_xor_si128(z47, z8b);
+        z47 = rotate_left_128!(z47, 12);
 
-            z03 = _mm_add_epi32(z03, z47);
-            zcf = _mm_xor_si128(zcf, z03);
-            zcf = rotate_left_128!(zcf, 8);
+        z03 = _mm_add_epi32(z03, z47);
+        zcf = _mm_xor_si128(zcf, z03);
+        zcf = rotate_left_128!(zcf, 8);
 
-            z8b = _mm_add_epi32(z8b, zcf);
-            z47 = _mm_xor_si128(z47, z8b);
-            z47 = rotate_left_128!(z47, 7);
+        z8b = _mm_add_epi32(z8b, zcf);
+        z47 = _mm_xor_si128(z47, z8b);
+        z47 = rotate_left_128!(z47, 7);
 
-            z47 = _mm_shuffle_epi32(z47, 0b00_11_10_01);
-            z8b = _mm_shuffle_epi32(z8b, 0b01_00_11_10);
-            zcf = _mm_shuffle_epi32(zcf, 0b10_01_00_11);
+        z47 = _mm_shuffle_epi32(z47, 0b00_11_10_01);
+        z8b = _mm_shuffle_epi32(z8b, 0b01_00_11_10);
+        zcf = _mm_shuffle_epi32(zcf, 0b10_01_00_11);
 
-            z03 = _mm_add_epi32(z03, z47);
-            zcf = _mm_xor_si128(zcf, z03);
-            zcf = rotate_left_128!(zcf, 16);
+        z03 = _mm_add_epi32(z03, z47);
+        zcf = _mm_xor_si128(zcf, z03);
+        zcf = rotate_left_128!(zcf, 16);
 
-            z8b = _mm_add_epi32(z8b, zcf);
-            z47 = _mm_xor_si128(z47, z8b);
-            z47 = rotate_left_128!(z47, 12);
+        z8b = _mm_add_epi32(z8b, zcf);
+        z47 = _mm_xor_si128(z47, z8b);
+        z47 = rotate_left_128!(z47, 12);
 
-            z03 = _mm_add_epi32(z03, z47);
-            zcf = _mm_xor_si128(zcf, z03);
-            zcf = rotate_left_128!(zcf, 8);
+        z03 = _mm_add_epi32(z03, z47);
+        zcf = _mm_xor_si128(zcf, z03);
+        zcf = rotate_left_128!(zcf, 8);
 
-            z8b = _mm_add_epi32(z8b, zcf);
-            z47 = _mm_xor_si128(z47, z8b);
-            z47 = rotate_left_128!(z47, 7);
+        z8b = _mm_add_epi32(z8b, zcf);
+        z47 = _mm_xor_si128(z47, z8b);
+        z47 = rotate_left_128!(z47, 7);
 
-            z47 = _mm_shuffle_epi32(z47, 0b10_01_00_11);
-            z8b = _mm_shuffle_epi32(z8b, 0b01_00_11_10);
-            zcf = _mm_shuffle_epi32(zcf, 0b00_11_10_01);
-        }
-
-        let z07 = _mm256_set_m128i(_mm_lddqu_si128(SIGMA.as_ptr().cast()), z03);
-
-        let mut chacha_nonce = [0u8; 16];
-        chacha_nonce[8..16].copy_from_slice(&nonce[16..24]);
-        let z8f = _mm256_set_m128i(zcf, _mm_lddqu_si128(chacha_nonce.as_ptr().cast()));
-
-        ChaCha20 { z07, z8f }
+        z47 = _mm_shuffle_epi32(z47, 0b10_01_00_11);
+        z8b = _mm_shuffle_epi32(z8b, 0b01_00_11_10);
+        zcf = _mm_shuffle_epi32(zcf, 0b00_11_10_01);
     }
+
+    // SAFETY: `SIGMA` is readable.
+    let z07 = _mm256_set_m128i(unsafe { _mm_lddqu_si128(SIGMA.as_ptr().cast()) }, z03);
+
+    let mut chacha_nonce = [0u8; 16];
+    chacha_nonce[8..16].copy_from_slice(&nonce[16..24]);
+    // SAFETY: `chacha_nonce` is certainly 16 bytes and readable.
+    let z8f = _mm256_set_m128i(zcf, unsafe {
+        _mm_lddqu_si128(chacha_nonce.as_ptr().cast())
+    });
+
+    ChaCha20 { z07, z8f }
 }
 
 const SIGMA: [u8; 16] = *b"expand 32-byte k";

--- a/graviola/src/low/x86_64/ghash.rs
+++ b/graviola/src/low/x86_64/ghash.rs
@@ -284,14 +284,12 @@ macro_rules! reduce {
 
 #[inline]
 #[target_feature(enable = "pclmulqdq,avx")]
-unsafe fn _mul(a: __m128i, b: __m128i) -> __m128i {
+fn _mul(a: __m128i, b: __m128i) -> __m128i {
     // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let (mut lo, mut mi, mut hi) = (zero(), zero(), zero());
-        let bx = xor_halves(b);
-        mul!(lo, mi, hi, a, b, bx);
-        reduce!(lo, mi, hi)
-    }
+    let (mut lo, mut mi, mut hi) = (zero(), zero(), zero());
+    let bx = xor_halves(b);
+    mul!(lo, mi, hi, a, b, bx);
+    reduce!(lo, mi, hi)
 }
 
 #[inline]

--- a/graviola/src/low/x86_64/ghash.rs
+++ b/graviola/src/low/x86_64/ghash.rs
@@ -223,10 +223,11 @@ impl<'a> Ghash<'a> {
     }
 
     #[target_feature(enable = "sse2,ssse3")]
-    unsafe fn _into_bytes(self) -> [u8; 16] {
+    fn _into_bytes(self) -> [u8; 16] {
         let mut out: i128 = 0;
         let reverse = _mm_shuffle_epi8(self.current, BYTESWAP);
-        _mm_store_si128(&mut out as *mut i128 as *mut __m128i, reverse);
+        // SAFETY: `out` is 128 bits, and a suitable target for a 128-bit aligned store
+        unsafe { _mm_store_si128(&mut out as *mut i128 as *mut __m128i, reverse) };
         out.to_le_bytes()
     }
 

--- a/graviola/src/low/x86_64/sha256.rs
+++ b/graviola/src/low/x86_64/sha256.rs
@@ -16,7 +16,10 @@ pub(in crate::low) fn sha256_compress_blocks_shaext(
 
 macro_rules! k {
     ($k:literal) => {
-        _mm_load_si128(K.0.as_ptr().add($k * 4) as *const _)
+        // SAFETY: `$k` is a compile-time constant and results in a valid index
+        // into the const table `K`.  `K` has proper alignment for this aligned
+        // load.
+        unsafe { _mm_load_si128(K.0.as_ptr().add($k * 4) as *const _) }
     };
 }
 
@@ -46,77 +49,88 @@ macro_rules! round {
 }
 
 #[target_feature(enable = "sha,sse4.1,ssse3")]
-unsafe fn sha256(state: &mut [u32; 8], blocks: &[u8]) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn sha256(state: &mut [u32; 8], blocks: &[u8]) {
+    let little_endian_shuffle = _mm_set_epi64x(0x0c0d0e0f08090a0b, 0x0405060700010203);
+
+    // SAFETY: `state` is 8 32-bit words and readable
+    let (state0, state1) = unsafe {
+        (
+            _mm_loadu_si128(state[0..4].as_ptr() as *const _),
+            _mm_loadu_si128(state[4..8].as_ptr() as *const _),
+        )
+    };
+
+    let tmp = _mm_shuffle_epi32(state0, 0b10_11_00_01);
+    let state1 = _mm_shuffle_epi32(state1, 0b00_01_10_11);
+    let mut state0 = _mm_alignr_epi8(tmp, state1, 8);
+    let mut state1 = _mm_blend_epi16(state1, tmp, 0xf0);
+
+    let k0 = k!(0);
+    let k1 = k!(1);
+    let k2 = k!(2);
+    let k3 = k!(3);
+    let k4 = k!(4);
+    let k5 = k!(5);
+    let k6 = k!(6);
+    let k7 = k!(7);
+    let k8 = k!(8);
+    let k9 = k!(9);
+    let k10 = k!(10);
+    let k11 = k!(11);
+    let k12 = k!(12);
+    let k13 = k!(13);
+    let k14 = k!(14);
+    let k15 = k!(15);
+
+    for block in blocks.chunks_exact(64) {
+        let state0_prev = state0;
+        let state1_prev = state1;
+
+        // SAFETY: `block` is 64 bytes and readable
+        let (msg0, msg1, msg2, msg3) = unsafe {
+            (
+                _mm_loadu_si128(block[0..].as_ptr() as *const _),
+                _mm_loadu_si128(block[16..].as_ptr() as *const _),
+                _mm_loadu_si128(block[32..].as_ptr() as *const _),
+                _mm_loadu_si128(block[48..].as_ptr() as *const _),
+            )
+        };
+
+        let msg0 = _mm_shuffle_epi8(msg0, little_endian_shuffle);
+        let msg1 = _mm_shuffle_epi8(msg1, little_endian_shuffle);
+        let msg2 = _mm_shuffle_epi8(msg2, little_endian_shuffle);
+        let msg3 = _mm_shuffle_epi8(msg3, little_endian_shuffle);
+
+        round!(msg0, state0, state1, k0);
+        round!(msg1, msg0, state0, state1, k1);
+        round!(msg2, msg1, state0, state1, k2);
+        round!(msg3, msg2, msg0, state0, state1, k3);
+        round!(msg0, msg3, msg1, state0, state1, k4);
+        round!(msg1, msg0, msg2, state0, state1, k5);
+        round!(msg2, msg1, msg3, state0, state1, k6);
+        round!(msg3, msg2, msg0, state0, state1, k7);
+        round!(msg0, msg3, msg1, state0, state1, k8);
+        round!(msg1, msg0, msg2, state0, state1, k9);
+        round!(msg2, msg1, msg3, state0, state1, k10);
+        round!(msg3, msg2, msg0, state0, state1, k11);
+        round!(msg0, msg3, msg1, state0, state1, k12);
+        round!(msg1, msg0, msg2, state0, state1, k13);
+        round!(msg2, msg1, msg3, state0, state1, k14);
+        round!(msg3, state0, state1, k15);
+        let _ = msg1;
+        let _ = msg0;
+
+        state0 = _mm_add_epi32(state0, state0_prev);
+        state1 = _mm_add_epi32(state1, state1_prev);
+    }
+
+    let tmp = _mm_shuffle_epi32(state0, 0b00_01_10_11);
+    let state1 = _mm_shuffle_epi32(state1, 0b10_11_00_01);
+    let state0 = _mm_blend_epi16(tmp, state1, 0xf0);
+    let state1 = _mm_alignr_epi8(state1, tmp, 8);
+
+    // SAFETY: `state` is 8 32-bit words and writable
     unsafe {
-        let little_endian_shuffle = _mm_set_epi64x(0x0c0d0e0f08090a0b, 0x0405060700010203);
-
-        let state0 = _mm_loadu_si128(state[0..4].as_ptr() as *const _);
-        let state1 = _mm_loadu_si128(state[4..8].as_ptr() as *const _);
-
-        let tmp = _mm_shuffle_epi32(state0, 0b10_11_00_01);
-        let state1 = _mm_shuffle_epi32(state1, 0b00_01_10_11);
-        let mut state0 = _mm_alignr_epi8(tmp, state1, 8);
-        let mut state1 = _mm_blend_epi16(state1, tmp, 0xf0);
-
-        let k0 = k!(0);
-        let k1 = k!(1);
-        let k2 = k!(2);
-        let k3 = k!(3);
-        let k4 = k!(4);
-        let k5 = k!(5);
-        let k6 = k!(6);
-        let k7 = k!(7);
-        let k8 = k!(8);
-        let k9 = k!(9);
-        let k10 = k!(10);
-        let k11 = k!(11);
-        let k12 = k!(12);
-        let k13 = k!(13);
-        let k14 = k!(14);
-        let k15 = k!(15);
-
-        for block in blocks.chunks_exact(64) {
-            let state0_prev = state0;
-            let state1_prev = state1;
-
-            let msg0 = _mm_loadu_si128(block[0..].as_ptr() as *const _);
-            let msg0 = _mm_shuffle_epi8(msg0, little_endian_shuffle);
-            let msg1 = _mm_loadu_si128(block[16..].as_ptr() as *const _);
-            let msg1 = _mm_shuffle_epi8(msg1, little_endian_shuffle);
-            let msg2 = _mm_loadu_si128(block[32..].as_ptr() as *const _);
-            let msg2 = _mm_shuffle_epi8(msg2, little_endian_shuffle);
-            let msg3 = _mm_loadu_si128(block[48..].as_ptr() as *const _);
-            let msg3 = _mm_shuffle_epi8(msg3, little_endian_shuffle);
-
-            round!(msg0, state0, state1, k0);
-            round!(msg1, msg0, state0, state1, k1);
-            round!(msg2, msg1, state0, state1, k2);
-            round!(msg3, msg2, msg0, state0, state1, k3);
-            round!(msg0, msg3, msg1, state0, state1, k4);
-            round!(msg1, msg0, msg2, state0, state1, k5);
-            round!(msg2, msg1, msg3, state0, state1, k6);
-            round!(msg3, msg2, msg0, state0, state1, k7);
-            round!(msg0, msg3, msg1, state0, state1, k8);
-            round!(msg1, msg0, msg2, state0, state1, k9);
-            round!(msg2, msg1, msg3, state0, state1, k10);
-            round!(msg3, msg2, msg0, state0, state1, k11);
-            round!(msg0, msg3, msg1, state0, state1, k12);
-            round!(msg1, msg0, msg2, state0, state1, k13);
-            round!(msg2, msg1, msg3, state0, state1, k14);
-            round!(msg3, state0, state1, k15);
-            let _ = msg1;
-            let _ = msg0;
-
-            state0 = _mm_add_epi32(state0, state0_prev);
-            state1 = _mm_add_epi32(state1, state1_prev);
-        }
-
-        let tmp = _mm_shuffle_epi32(state0, 0b00_01_10_11);
-        let state1 = _mm_shuffle_epi32(state1, 0b10_11_00_01);
-        let state0 = _mm_blend_epi16(tmp, state1, 0xf0);
-        let state1 = _mm_alignr_epi8(state1, tmp, 8);
-
         _mm_storeu_si128(state[0..4].as_mut_ptr() as *mut _, state0);
         _mm_storeu_si128(state[4..8].as_mut_ptr() as *mut _, state1);
     }

--- a/graviola/src/low/x86_64/sha512.rs
+++ b/graviola/src/low/x86_64/sha512.rs
@@ -19,7 +19,7 @@ fn maj(x: u64, y: u64, z: u64) -> u64 {
 }
 
 #[inline]
-unsafe fn bsig0(x: u64) -> u64 {
+fn bsig0(x: u64) -> u64 {
     // equiv. x.rotate_right(28) ^ x.rotate_right(34) ^ x.rotate_right(39)
     let mut ret;
 
@@ -41,7 +41,7 @@ unsafe fn bsig0(x: u64) -> u64 {
 }
 
 #[inline]
-unsafe fn bsig1(x: u64) -> u64 {
+fn bsig1(x: u64) -> u64 {
     // equiv. x.rotate_right(14) ^ x.rotate_right(18) ^ x.rotate_right(41)
     let mut ret;
     // SAFETY: inline assembly. see [crate::low::inline_assembly_safety] for safety info.
@@ -63,7 +63,7 @@ unsafe fn bsig1(x: u64) -> u64 {
 
 #[inline]
 #[target_feature(enable = "avx,avx2")]
-unsafe fn sigma_0(w: __m256i) -> __m256i {
+fn sigma_0(w: __m256i) -> __m256i {
     _mm256_xor_si256(
         _mm256_xor_si256(
             _mm256_xor_si256(_mm256_srli_epi64(w, 7), _mm256_srli_epi64(w, 8)),
@@ -75,7 +75,7 @@ unsafe fn sigma_0(w: __m256i) -> __m256i {
 
 #[inline]
 #[target_feature(enable = "avx,avx2")]
-unsafe fn sigma_1(w: __m256i) -> __m256i {
+fn sigma_1(w: __m256i) -> __m256i {
     _mm256_xor_si256(
         _mm256_xor_si256(
             _mm256_xor_si256(_mm256_srli_epi64(w, 6), _mm256_srli_epi64(w, 61)),
@@ -105,8 +105,8 @@ macro_rules! schedule_round {
 }
 
 #[target_feature(enable = "avx,avx2,bmi2")]
-unsafe fn sha512_quad_message_schedule(schedule: &mut [__m256i; 80], message: *const u64) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn sha512_quad_message_schedule(schedule: &mut [__m256i; 80], message: *const u64) {
+    // SAFETY: `message` is 16 x 64-bit words and readable
     unsafe {
         let gather_mask = _mm256_setr_epi64x(0, 16, 32, 48);
         let mut w0 = _mm256_i64gather_epi64(message.add(0).cast(), gather_mask, 8);
@@ -193,136 +193,141 @@ macro_rules! round {
 }
 
 #[target_feature(enable = "avx,avx2,bmi2")]
-unsafe fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
+fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
+    let mut w = [_mm256_setzero_si256(); 80];
+    sha512_quad_message_schedule(&mut w, block4);
+
+    // keep intermediate state in ymm registers to reduce scalar register
+    // pressure
+    // SAFETY: `state` is 8 x 64-bit words and readable
+    let (save_abcd, save_efgh) = unsafe {
+        (
+            _mm256_loadu_si256(state.as_ptr().add(0).cast()),
+            _mm256_loadu_si256(state.as_ptr().add(4).cast()),
+        )
+    };
+
+    // block 1
+    let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
+    let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
+    let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
+    let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
+    let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
+    let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
+    let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
+    let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
+    for w_t in w.chunks_exact(8) {
+        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 0));
+        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 0));
+        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 0));
+        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 0));
+        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 0));
+        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 0));
+        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 0));
+        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 0));
+    }
+
+    let save_abcd = _mm256_add_epi64(
+        save_abcd,
+        _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
+    );
+    let save_efgh = _mm256_add_epi64(
+        save_efgh,
+        _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
+    );
+
+    // block 2
+    let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
+    let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
+    let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
+    let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
+    let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
+    let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
+    let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
+    let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
+
+    for w_t in w.chunks_exact(8) {
+        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 1));
+        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 1));
+        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 1));
+        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 1));
+        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 1));
+        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 1));
+        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 1));
+        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 1));
+    }
+
+    let save_abcd = _mm256_add_epi64(
+        save_abcd,
+        _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
+    );
+    let save_efgh = _mm256_add_epi64(
+        save_efgh,
+        _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
+    );
+
+    // block 3
+    let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
+    let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
+    let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
+    let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
+    let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
+    let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
+    let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
+    let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
+
+    for w_t in w.chunks_exact(8) {
+        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 2));
+        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 2));
+        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 2));
+        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 2));
+        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 2));
+        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 2));
+        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 2));
+        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 2));
+    }
+
+    let save_abcd = _mm256_add_epi64(
+        save_abcd,
+        _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
+    );
+    let save_efgh = _mm256_add_epi64(
+        save_efgh,
+        _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
+    );
+
+    // block 4
+    let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
+    let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
+    let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
+    let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
+    let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
+    let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
+    let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
+    let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
+
+    for w_t in w.chunks_exact(8) {
+        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 3));
+        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 3));
+        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 3));
+        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 3));
+        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 3));
+        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 3));
+        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 3));
+        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 3));
+    }
+
+    let save_abcd = _mm256_add_epi64(
+        save_abcd,
+        _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
+    );
+    let save_efgh = _mm256_add_epi64(
+        save_efgh,
+        _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
+    );
+
+    // SAFETY: `state` is 8 x 64-bit words and writable
     unsafe {
-        let mut w = [_mm256_setzero_si256(); 80];
-        sha512_quad_message_schedule(&mut w, block4);
-
-        // keep intermediate state in ymm registers to reduce scalar register
-        // pressure
-        let save_abcd = _mm256_loadu_si256(state.as_ptr().add(0).cast());
-        let save_efgh = _mm256_loadu_si256(state.as_ptr().add(4).cast());
-
-        // block 1
-        let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
-        let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
-        let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
-        let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
-        let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
-        let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
-        let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
-        let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
-        for w_t in w.chunks_exact(8) {
-            round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 0));
-            round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 0));
-            round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 0));
-            round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 0));
-            round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 0));
-            round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 0));
-            round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 0));
-            round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 0));
-        }
-
-        let save_abcd = _mm256_add_epi64(
-            save_abcd,
-            _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
-        );
-        let save_efgh = _mm256_add_epi64(
-            save_efgh,
-            _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
-        );
-
-        // block 2
-        let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
-        let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
-        let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
-        let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
-        let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
-        let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
-        let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
-        let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
-
-        for w_t in w.chunks_exact(8) {
-            round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 1));
-            round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 1));
-            round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 1));
-            round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 1));
-            round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 1));
-            round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 1));
-            round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 1));
-            round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 1));
-        }
-
-        let save_abcd = _mm256_add_epi64(
-            save_abcd,
-            _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
-        );
-        let save_efgh = _mm256_add_epi64(
-            save_efgh,
-            _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
-        );
-
-        // block 3
-        let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
-        let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
-        let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
-        let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
-        let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
-        let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
-        let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
-        let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
-
-        for w_t in w.chunks_exact(8) {
-            round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 2));
-            round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 2));
-            round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 2));
-            round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 2));
-            round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 2));
-            round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 2));
-            round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 2));
-            round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 2));
-        }
-
-        let save_abcd = _mm256_add_epi64(
-            save_abcd,
-            _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
-        );
-        let save_efgh = _mm256_add_epi64(
-            save_efgh,
-            _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
-        );
-
-        // block 4
-        let mut a = _mm256_extract_epi64(save_abcd, 0) as u64;
-        let mut b = _mm256_extract_epi64(save_abcd, 1) as u64;
-        let mut c = _mm256_extract_epi64(save_abcd, 2) as u64;
-        let mut d = _mm256_extract_epi64(save_abcd, 3) as u64;
-        let mut e = _mm256_extract_epi64(save_efgh, 0) as u64;
-        let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
-        let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
-        let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
-
-        for w_t in w.chunks_exact(8) {
-            round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 3));
-            round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 3));
-            round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 3));
-            round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(w_t[3], 3));
-            round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(w_t[4], 3));
-            round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(w_t[5], 3));
-            round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(w_t[6], 3));
-            round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(w_t[7], 3));
-        }
-
-        let save_abcd = _mm256_add_epi64(
-            save_abcd,
-            _mm256_set_epi64x(d as i64, c as i64, b as i64, a as i64),
-        );
-        let save_efgh = _mm256_add_epi64(
-            save_efgh,
-            _mm256_set_epi64x(h as i64, g as i64, f as i64, e as i64),
-        );
-
         _mm256_storeu_si256(state.as_ptr().add(0) as *mut _, save_abcd);
         _mm256_storeu_si256(state.as_ptr().add(4) as *mut _, save_efgh);
     }
@@ -337,9 +342,11 @@ unsafe fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
 /// Returns both W, and W+K
 macro_rules! input {
     ($block:ident, $i:literal) => {{
-        let w = _mm256_loadu_si256($block.as_ptr().add($i * 32).cast());
+        // SAFETY: `$block` is 128 bytes, and `$i` is 0..4.
+        let w = unsafe { _mm256_loadu_si256($block.as_ptr().add($i * 32).cast()) };
         let w = _mm256_shuffle_epi8(w, BSWAP_SHUFFLE);
-        let k = _mm256_loadu_si256(K.as_ptr().add($i * 4).cast());
+        // SAFETY: `$i` is 0..4 and `K` is a constant table.
+        let k = unsafe { _mm256_loadu_si256(K.as_ptr().add($i * 4).cast()) };
         let wk = _mm256_add_epi64(w, k);
         (w, wk)
     }};
@@ -395,64 +402,63 @@ macro_rules! schedule {
 /// That means we interleave computing four words of W, followed by
 /// four rounds.
 #[target_feature(enable = "avx,avx2,bmi2")]
-unsafe fn sha512_compress_block(state: &mut [u64; 8], block: &[u8]) {
-    // SAFETY: intrinsics. see [crate::low::inline_assembly_safety#safety-of-intrinsics] for safety info.
-    unsafe {
-        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
-        let (w0_3, wk0_3) = input!(block, 0);
-        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(wk0_3, 0));
-        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(wk0_3, 1));
-        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(wk0_3, 2));
-        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(wk0_3, 3));
-        let (w4_7, wk4_7) = input!(block, 1);
-        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(wk4_7, 0));
-        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(wk4_7, 1));
-        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(wk4_7, 2));
-        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(wk4_7, 3));
-        let (w8_11, wk8_11) = input!(block, 2);
-        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(wk8_11, 0));
-        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(wk8_11, 1));
-        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(wk8_11, 2));
-        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(wk8_11, 3));
-        let (w12_15, wk12_15) = input!(block, 3);
-        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(wk12_15, 0));
-        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(wk12_15, 1));
-        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(wk12_15, 2));
-        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(wk12_15, 3));
+fn sha512_compress_block(state: &mut [u64; 8], block: &[u8]) {
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+    let (w0_3, wk0_3) = input!(block, 0);
+    round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(wk0_3, 0));
+    round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(wk0_3, 1));
+    round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(wk0_3, 2));
+    round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(wk0_3, 3));
+    let (w4_7, wk4_7) = input!(block, 1);
+    round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(wk4_7, 0));
+    round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(wk4_7, 1));
+    round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(wk4_7, 2));
+    round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(wk4_7, 3));
+    let (w8_11, wk8_11) = input!(block, 2);
+    round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(wk8_11, 0));
+    round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(wk8_11, 1));
+    round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(wk8_11, 2));
+    round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(wk8_11, 3));
+    let (w12_15, wk12_15) = input!(block, 3);
+    round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(wk12_15, 0));
+    round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(wk12_15, 1));
+    round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(wk12_15, 2));
+    round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(wk12_15, 3));
 
-        // window of 16 W values
-        let (mut wm4, mut wm3, mut wm2, mut wm1) = (w0_3, w4_7, w8_11, w12_15);
+    // window of 16 W values
+    let (mut wm4, mut wm3, mut wm2, mut wm1) = (w0_3, w4_7, w8_11, w12_15);
 
-        for t in (16..80).step_by(8) {
-            let k0 = _mm256_loadu_si256(K.as_ptr().add(t).cast());
-            let (w_t, wk_t) = schedule!(wm4, wm3, wm2, wm1, k0);
-            round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(wk_t, 0));
-            round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(wk_t, 1));
-            round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(wk_t, 2));
-            round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(wk_t, 3));
+    for t in (16..80).step_by(8) {
+        // SAFETY: `K` is a constant table of 80 words.
+        let k0 = unsafe { _mm256_loadu_si256(K.as_ptr().add(t).cast()) };
+        let (w_t, wk_t) = schedule!(wm4, wm3, wm2, wm1, k0);
+        round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(wk_t, 0));
+        round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(wk_t, 1));
+        round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(wk_t, 2));
+        round!(f, g, h, a, b, c, d, e, _mm256_extract_epi64(wk_t, 3));
 
-            let k4 = _mm256_loadu_si256(K.as_ptr().add(t + 4).cast());
-            let (w_t1, wk_t1) = schedule!(wm3, wm2, wm1, w_t, k4);
-            round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(wk_t1, 0));
-            round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(wk_t1, 1));
-            round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(wk_t1, 2));
-            round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(wk_t1, 3));
+        // SAFETY: `K` is a constant table of 80 words.
+        let k4 = unsafe { _mm256_loadu_si256(K.as_ptr().add(t + 4).cast()) };
+        let (w_t1, wk_t1) = schedule!(wm3, wm2, wm1, w_t, k4);
+        round!(e, f, g, h, a, b, c, d, _mm256_extract_epi64(wk_t1, 0));
+        round!(d, e, f, g, h, a, b, c, _mm256_extract_epi64(wk_t1, 1));
+        round!(c, d, e, f, g, h, a, b, _mm256_extract_epi64(wk_t1, 2));
+        round!(b, c, d, e, f, g, h, a, _mm256_extract_epi64(wk_t1, 3));
 
-            wm4 = wm2;
-            wm3 = wm1;
-            wm2 = w_t;
-            wm1 = w_t1;
-        }
-
-        state[0] = state[0].wrapping_add(a);
-        state[1] = state[1].wrapping_add(b);
-        state[2] = state[2].wrapping_add(c);
-        state[3] = state[3].wrapping_add(d);
-        state[4] = state[4].wrapping_add(e);
-        state[5] = state[5].wrapping_add(f);
-        state[6] = state[6].wrapping_add(g);
-        state[7] = state[7].wrapping_add(h);
+        wm4 = wm2;
+        wm3 = wm1;
+        wm2 = w_t;
+        wm1 = w_t1;
     }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
 }
 
 pub(in crate::low) fn sha512_compress_blocks(

--- a/rustls-graviola/Cargo.toml
+++ b/rustls-graviola/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rustls-graviola"
 version = "0.2.1"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/ctz/graviola/"
 license = "Apache-2.0 OR ISC OR MIT-0"
 description = "graviola is a modern, fast cryptography library"
 categories = ["network-programming", "cryptography"]
-rust-version = "1.72"
+rust-version = "1.85"
 readme = "README.md"
 
 [dependencies]

--- a/rustls-graviola/examples/client.rs
+++ b/rustls-graviola/examples/client.rs
@@ -22,7 +22,7 @@ fn main() {
 }
 
 fn error(err: String) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, err)
+    io::Error::other(err)
 }
 
 #[tokio::main]

--- a/rustls-graviola/examples/server.rs
+++ b/rustls-graviola/examples/server.rs
@@ -29,7 +29,7 @@ fn main() {
 }
 
 fn error(err: String) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, err)
+    io::Error::other(err)
 }
 
 #[tokio::main]

--- a/x86-cpuid/Cargo.toml
+++ b/x86-cpuid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-cpuid"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
This moves around most `unsafe` blocks for intrinsics, to take advantage of the improved safety of these.