### PR TITLE
Obtain coverage for AVX512 codepaths

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,18 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - uses: actions/checkout@v4
+        if: runner.os == 'Linux'
+        with:
+          repository: ctz/intel-sde
+          path: thirdparty/intel-sde
+          persist-credentials: false
+
+      - name: Set up Intel SDE
+        if: runner.os == 'Linux'
+        run: |
+          echo "PATH=$(pwd)/thirdparty/intel-sde:$PATH" >> $GITHUB_ENV
+
       - name: Measure coverage
         run: ./admin/coverage --lcov --output-path final.info
 

--- a/admin/coverage
+++ b/admin/coverage
@@ -9,8 +9,8 @@ cargo llvm-cov clean --workspace
 env SLOW_TESTS=1 cargo test --locked --all-features
 
 if [ `uname -p` == "x86_64" ] ; then
-    env GRAVIOLA_CPU_DISABLE_sha=1 GRAVIOLA_CPU_DISABLE_bmi2=1 cargo test --locked
-    env GRAVIOLA_CPU_DISABLE_avx512bw=1 GRAVIOLA_CPU_DISABLE_avx512f=1 GRAVIOLA_CPU_DISABLE_vaes=1 cargo test --locked
+    env GRAVIOLA_CPU_DISABLE_sha=1 GRAVIOLA_CPU_DISABLE_bmi2=1 GRAVIOLA_CPU_DISABLE_avx512bw=1 GRAVIOLA_CPU_DISABLE_avx512f=1 GRAVIOLA_CPU_DISABLE_vaes=1 cargo test --locked
+    env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sde -dmr --" cargo test --locked
 fi
 cargo run --example client https://jbp.io >/dev/null
 


### PR DESCRIPTION
GHA runners don't support this, so we need to run the tests also under intel-sde.