### PR TITLE
fuzz: use upstream lockfile

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,7 +21,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install --locked cargo-fuzz
 
       - name: Smoke-test fuzz targets
         run: |


### PR DESCRIPTION
This is mega broken otherwise. See https://github.com/rust-lang/cfg-if/issues/90