### PR TITLE
Correct `target_feature` of `_zero_bytes`

### DIFF
--- a/graviola/src/low/x86_64/cpu.rs
+++ b/graviola/src/low/x86_64/cpu.rs
@@ -52,7 +52,7 @@ pub(in crate::low) fn zero_bytes(ptr: *mut u8, len: usize) {
     unsafe { _zero_bytes(ptr, len) }
 }
 
-#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx,avx2")]
 unsafe fn _zero_bytes(ptr: *mut u8, len: usize) {
     // SAFETY: writes to `len` bytes at `ptr`, which the caller guarantees
     unsafe {


### PR DESCRIPTION
vpxor with ymm registers is avx2.

This has no effect, but is a clarity problem.

Related to #127  but does not help.