### PR TITLE
Add test coverage for some error cases

### DIFF
--- a/graviola/src/high/asn1.rs
+++ b/graviola/src/high/asn1.rs
@@ -1184,6 +1184,13 @@ mod tests {
         assert_eq!(encoded_length_for(65536), 5 + 65536);
         assert_eq!(encoded_length_for(16777215), 5 + 16777215);
         assert_eq!(encoded_length_for(16777216), 6 + 16777216);
+        assert_eq!(encoded_length_for(4294967295), 6 + 4294967295);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_encode_len_limit() {
+        let _ = encoded_length_for(4294967296);
     }
 
     #[test]

--- a/graviola/src/high/curve.rs
+++ b/graviola/src/high/curve.rs
@@ -306,6 +306,21 @@ mod tests {
     use crate::test::*;
 
     #[test]
+    fn private_key_encode_error() {
+        let key = p256::StaticPrivateKey::new_random().unwrap();
+        let mut out = [0; 31];
+        assert!(key.encode(&mut out).is_err());
+        let mut out = [0; 64];
+        assert!(key.public_key_encode_uncompressed(&mut out).is_err());
+
+        let key = p384::StaticPrivateKey::new_random().unwrap();
+        let mut out = [0; 47];
+        assert!(key.encode(&mut out).is_err());
+        let mut out = [0; 96];
+        assert!(key.public_key_encode_uncompressed(&mut out).is_err());
+    }
+
+    #[test]
     fn cavp_pkv() {
         #[derive(Debug, Default)]
         struct State {

--- a/graviola/src/low/posint.rs
+++ b/graviola/src/low/posint.rs
@@ -994,6 +994,25 @@ mod tests {
         assert!(two_words.is_odd());
         assert!(two_words.equals(&two_words));
         assert!(two_words.fixed_one().less_than(&two_words));
+
+        let mut two_words = PosInt::<2>::zero();
+        const LOW_ORDER_WORD: u64 = 0xfedcba9876543210;
+        const HIGH_ORDER_WORD: u64 = 0x1234;
+        assert!(two_words.push_word(LOW_ORDER_WORD).is_ok());
+        assert!(two_words.push_word(HIGH_ORDER_WORD).is_ok());
+        assert!(two_words.push_word(0).is_err());
+        let mut out = [0; 15];
+        assert!(two_words.to_bytes(&mut out).is_err());
+        let mut out = [0; 16];
+        assert!(two_words.to_bytes(&mut out).is_ok());
+        assert_eq!(
+            u64::from_be_bytes(out[0..8].try_into().unwrap()),
+            HIGH_ORDER_WORD
+        );
+        assert_eq!(
+            u64::from_be_bytes(out[8..16].try_into().unwrap()),
+            LOW_ORDER_WORD
+        );
     }
 
     #[test]


### PR DESCRIPTION
* ASN.1 encoded_length_for with a length that is out of range
* p256/p384 PrivateKey<C>::encode with an output buffer that is too small
* PosInt::push_word when the internal buffer is full