### PR TITLE
Convert to `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "cfg-if",
  "crabgrind",
  "getrandom 0.3.4",
+ "graviola",
  "hex",
  "proptest",
  "serde",

--- a/graviola/Cargo.toml
+++ b/graviola/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.89"
 
 [features]
 default = []
+std = []
 
 [dependencies]
 cfg-if = "1"
@@ -18,6 +19,7 @@ getrandom = "0.3"
 
 [dev-dependencies]
 aws-lc-rs = { version = "1.13", default-features = false, features = ["alloc", "prebuilt-nasm", "non-fips"] }
+graviola = { features = ["std"], path = "." }
 hex = { version = "0.4", features = ["serde"] }
 proptest = "1.5.0"
 serde = { version = "1", features = ["derive"] }

--- a/graviola/src/error.rs
+++ b/graviola/src/error.rs
@@ -93,6 +93,7 @@ impl core::error::Error for Error {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
 
     #[test]
     fn test_error_display() {

--- a/graviola/src/high/asn1.rs
+++ b/graviola/src/high/asn1.rs
@@ -874,6 +874,7 @@ pub(crate) mod pkix;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, vec};
 
     #[test]
     fn test_integer_encoding() {

--- a/graviola/src/high/asn1/pkix.rs
+++ b/graviola/src/high/asn1/pkix.rs
@@ -86,6 +86,9 @@ asn1_struct! {
 mod tests {
     use super::*;
     use crate::high::asn1::{Any, Encoder, Error, Null, OctetString, Parser, Type, oid};
+    use alloc::vec;
+    use std::dbg;
+    use std::println;
 
     #[test]
     fn parse_public_key() {

--- a/graviola/src/high/curve.rs
+++ b/graviola/src/high/curve.rs
@@ -304,6 +304,8 @@ impl Scalar<P384> for p384::Scalar {
 mod tests {
     use super::*;
     use crate::test::*;
+    use alloc::{string::String, string::ToString, vec, vec::Vec};
+    use std::println;
 
     #[test]
     fn private_key_encode_error() {

--- a/graviola/src/high/ecdsa.rs
+++ b/graviola/src/high/ecdsa.rs
@@ -359,6 +359,8 @@ mod tests {
     use crate::mid::rng::SliceRandomSource;
     use crate::mid::rng::SystemRandom;
     use crate::test::*;
+    use alloc::{string::String, string::ToString, vec, vec::Vec};
+    use std::println;
 
     #[test]
     fn smoke_test_loading_keys() {

--- a/graviola/src/high/ed25519.rs
+++ b/graviola/src/high/ed25519.rs
@@ -168,6 +168,7 @@ impl Ed25519SigningKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn pairwise() {

--- a/graviola/src/high/hash.rs
+++ b/graviola/src/high/hash.rs
@@ -263,6 +263,7 @@ impl HashContext for Sha512Context {
 mod tests {
     use super::*;
     use crate::test::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn cavp() {

--- a/graviola/src/high/hmac.rs
+++ b/graviola/src/high/hmac.rs
@@ -77,6 +77,8 @@ mod tests {
     use super::*;
     use crate::high::hash::{Sha256, Sha384, Sha512};
     use crate::test::*;
+    use alloc::vec::Vec;
+    use std::println;
 
     #[test]
     fn smoke() {

--- a/graviola/src/high/pkcs1.rs
+++ b/graviola/src/high/pkcs1.rs
@@ -249,6 +249,8 @@ mod tests {
     use crate::high::asn1::{self, Type, oid, pkix};
     use crate::high::hash;
     use crate::mid::rng::SliceRandomSource;
+    use alloc::{vec, vec::Vec};
+    use std::println;
 
     #[test]
     fn digestinfo_sha256_is_correct() {

--- a/graviola/src/high/pkcs8.rs
+++ b/graviola/src/high/pkcs8.rs
@@ -106,6 +106,7 @@ impl<'a> Key<'a> {
 mod tests {
     use super::*;
     use crate::high::asn1::oid;
+    use alloc::vec;
 
     #[test]
     fn round_trip_ed25519_v2() {

--- a/graviola/src/high/rsa.rs
+++ b/graviola/src/high/rsa.rs
@@ -537,6 +537,8 @@ impl SigningKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
+    use std::println;
 
     fn check_all_algs(buf: &mut [u8], private: &SigningKey, public: &VerifyingKey) {
         let sig = private.sign_pkcs1_sha256(buf, b"hello").unwrap();

--- a/graviola/src/lib.rs
+++ b/graviola/src/lib.rs
@@ -24,6 +24,11 @@
     unused_extern_crates,
     unused_qualifications
 )]
+#![no_std]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 /// Low level operations.
 ///

--- a/graviola/src/low/ct.rs
+++ b/graviola/src/low/ct.rs
@@ -8,7 +8,7 @@ cfg_if::cfg_if! {
 
         #[inline]
         pub(crate) fn secret_slice<T>(v: &[T]) {
-            cg::monitor_command(format!(
+            cg::monitor_command(std::format!(
                 "make_memory undefined {:p} {}",
                 v.as_ptr(),
                 size_of_val(v)
@@ -18,7 +18,7 @@ cfg_if::cfg_if! {
 
         #[inline]
         pub(crate) fn public_slice<T>(v: &[T]) {
-            cg::monitor_command(format!(
+            cg::monitor_command(std::format!(
                 "make_memory defined {:p} {}",
                 v.as_ptr(),
                 size_of_val(v)
@@ -29,7 +29,7 @@ cfg_if::cfg_if! {
         #[inline]
         #[must_use]
         pub(crate) fn into_secret<T>(v: T) -> T {
-            cg::monitor_command(format!(
+            cg::monitor_command(std::format!(
                 "make_memory undefined {:p} {}",
                 &v as *const T,
                 size_of_val(&v)
@@ -41,7 +41,7 @@ cfg_if::cfg_if! {
         #[inline]
         #[must_use]
         pub(crate) fn into_public<T>(v: T) -> T {
-            cg::monitor_command(format!(
+            cg::monitor_command(std::format!(
                 "make_memory defined {:p} {}",
                 &v as *const T,
                 size_of_val(&v)

--- a/graviola/src/low/posint.rs
+++ b/graviola/src/low/posint.rs
@@ -1,6 +1,7 @@
 // Written for Graviola by Joe Birr-Pixton, 2024.
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
 
+use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 use crate::Error;
@@ -125,15 +126,15 @@ impl<const N: usize> PosInt<N> {
         Ok(out)
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn debug(&self, why: &str) {
         let mut bytes = [0u8; 1024];
         let bytes = self.to_bytes(&mut bytes).unwrap();
-        print!("{why} = 0x");
+        std::print!("{why} = 0x");
         for b in bytes {
-            print!("{b:02x}");
+            std::print!("{b:02x}");
         }
-        println!();
+        std::println!();
     }
 
     pub(crate) fn len_bytes(&self) -> usize {
@@ -162,7 +163,7 @@ impl<const N: usize> PosInt<N> {
 
     /// Return true if `gcd(self, other)` is one
     pub(crate) fn is_coprime(&self, other: &Self) -> bool {
-        let mut tmp = vec![0u64; N + N];
+        let mut tmp = alloc::vec![0u64; N + N];
         low::bignum_coprime(self.as_words(), other.as_words(), &mut tmp)
     }
 
@@ -643,7 +644,7 @@ impl<const N: usize> PosInt<N> {
     pub(crate) fn mod_inverse(&self, n: &Self) -> Self {
         let mut r = Self::zero();
         r.used = n.used;
-        let mut temp = vec![0u64; N * 3];
+        let mut temp = alloc::vec![0u64; N * 3];
         low::bignum_modinv(
             r.as_mut_words(),
             self.as_words_with_len_of(n),
@@ -925,7 +926,7 @@ mod tests {
     #[test]
     fn to_bytes() {
         let mut buf = [0xff; 8];
-        assert_eq!(PosInt::<2>::zero().to_bytes(&mut buf).unwrap(), &[]);
+        assert_eq!(PosInt::<2>::zero().to_bytes(&mut buf).unwrap(), &[][..]);
 
         let all_bits_set = PosInt::<2>::from_bytes(&[0xff; 16]).unwrap();
         assert_eq!(
@@ -974,7 +975,7 @@ mod tests {
         let x_4 = PosInt::<4>::from_bytes(b"\xed\x1f\xde\xb5\xc6\x39\x43\x8f\xea\x1d\x05\x9c\xba\xa8\xd3\x7c\x13\x96\xf4\x96\x1c\x8e\x5f\x52\x8f\x3c\x4c\x3c\x45\xe5\x75\xa2").unwrap();
         let y_4 = PosInt::<4>::from_bytes(b"\x38\x8f\xb5\xd8\xbd\xad\x46\xfd\xe2\x8e\x33\x11\xe4\xdd\xef\x79\x70\xfe\x4a\xb9\xef\x24\x85\xbe\x4f\xde\x81\x79\x36\x0c\x9c\x86").unwrap();
         let xy_8: PosInt<8> = PosInt::mul(&x_4, &y_4);
-        println!("{xy_8:x?}");
+        std::println!("{xy_8:x?}");
 
         let expect_8 = PosInt::<8>::from_bytes(b"\x34\x64\x15\xf5\x75\xf1\xb7\x01\x8b\x1d\xc4\x68\xde\x4b\xf7\x6e\x6f\x62\x87\xa1\x44\x08\x6f\xb1\x85\x9c\xf3\x84\x41\x64\x48\x9d\x16\xe7\xb0\xd0\xd3\x56\x13\xba\xa2\xb9\xa6\x12\x1a\x6c\x2f\x93\xcd\xe4\x20\xfa\x41\xa4\xef\xa2\xab\xcd\x8b\x48\x19\x62\x4a\xcc").unwrap();
         assert!(xy_8.pub_equals(&expect_8));

--- a/graviola/src/low/tests.rs
+++ b/graviola/src/low/tests.rs
@@ -1,6 +1,8 @@
 // Written for Graviola by Joe Birr-Pixton, 2024.
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
 
+use alloc::vec;
+
 fn bignum_mux_equiv(p: u64, x_if_p: &[u64], y_if_not_p: &[u64]) {
     let mut model_z = vec![0; x_if_p.len()];
     let mut real_z = vec![0; x_if_p.len()];

--- a/graviola/src/low/x86_64/aes_gcm.rs
+++ b/graviola/src/low/x86_64/aes_gcm.rs
@@ -494,11 +494,13 @@ const BYTESWAP_512_EPI64: __m512i = unsafe {
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
+    use std::println;
+
     #[test]
     fn check_counter512() {
         use super::*;
 
-        if !is_x86_feature_detected!("avx512f") {
+        if !std::is_x86_feature_detected!("avx512f") {
             println!("no AVX512 support");
             return;
         }

--- a/graviola/src/low/x86_64/cpu.rs
+++ b/graviola/src/low/x86_64/cpu.rs
@@ -119,44 +119,50 @@ pub(in crate::low) unsafe fn ct_compare_bytes(a: *const u8, b: *const u8, len: u
 /// allow testability.
 macro_rules! have_cpu_feature {
     ("aes") => {
-        crate::low::x86_64::cpu::test_toggle("aes", is_x86_feature_detected!("aes"))
+        have_cpu_feature!(@_inner "aes")
     };
     ("vaes") => {
-        crate::low::x86_64::cpu::test_toggle("vaes", is_x86_feature_detected!("vaes"))
+        have_cpu_feature!(@_inner "vaes")
     };
     ("pclmulqdq") => {
-        crate::low::x86_64::cpu::test_toggle("pclmulqdq", is_x86_feature_detected!("pclmulqdq"))
+        have_cpu_feature!(@_inner "pclmulqdq")
     };
     ("vpclmulqdq") => {
-        crate::low::x86_64::cpu::test_toggle("vpclmulqdq", is_x86_feature_detected!("vpclmulqdq"))
+        have_cpu_feature!(@_inner "vpclmulqdq")
     };
     ("bmi1") => {
-        crate::low::x86_64::cpu::test_toggle("bmi1", is_x86_feature_detected!("bmi1"))
+        have_cpu_feature!(@_inner "bmi1")
     };
     ("bmi2") => {
-        crate::low::x86_64::cpu::test_toggle("bmi2", is_x86_feature_detected!("bmi2"))
+        have_cpu_feature!(@_inner "bmi2")
     };
     ("adx") => {
-        crate::low::x86_64::cpu::test_toggle("adx", is_x86_feature_detected!("adx"))
+        have_cpu_feature!(@_inner "adx")
     };
     ("avx") => {
-        crate::low::x86_64::cpu::test_toggle("avx", is_x86_feature_detected!("avx"))
+        have_cpu_feature!(@_inner "avx")
     };
     ("avx2") => {
-        crate::low::x86_64::cpu::test_toggle("avx2", is_x86_feature_detected!("avx2"))
+        have_cpu_feature!(@_inner "avx2")
     };
     ("avx512f") => {
-        crate::low::x86_64::cpu::test_toggle("avx512f", is_x86_feature_detected!("avx512f"))
+        have_cpu_feature!(@_inner "avx512f")
     };
     ("avx512bw") => {
-        crate::low::x86_64::cpu::test_toggle("avx512bw", is_x86_feature_detected!("avx512bw"))
+        have_cpu_feature!(@_inner "avx512bw")
     };
     ("avx512vl") => {
-        crate::low::x86_64::cpu::test_toggle("avx512vl", is_x86_feature_detected!("avx512vl"))
+        have_cpu_feature!(@_inner "avx512vl")
     };
     ("sha") => {
-        crate::low::x86_64::cpu::test_toggle("sha", is_x86_feature_detected!("sha"))
+        have_cpu_feature!(@_inner "sha")
     };
+    (@_inner $feature:tt) => {{
+        #[cfg(feature = "std")]
+        { crate::low::x86_64::cpu::test_toggle($feature, std::is_x86_feature_detected!($feature)) }
+        #[cfg(not(feature = "std"))]
+        { crate::low::x86_64::cpu::test_toggle("", false) }
+    }}
 }
 
 /// Token type reflecting the check for CPU features needed for AVX512-AES-GCM
@@ -208,18 +214,21 @@ impl HaveBmi2 {
         }
     }
 }
-#[cfg(not(debug_assertions))]
-pub(crate) fn test_toggle(_id: &str, detected: bool) -> bool {
-    detected
-}
 
-#[cfg(debug_assertions)]
-pub(crate) fn test_toggle(id: &str, detected: bool) -> bool {
-    if std::env::var(format!("GRAVIOLA_CPU_DISABLE_{id}")).is_ok() {
-        println!("DEBUG: denying cpuid {id:?}");
-        false
+cfg_if::cfg_if! {
+    if #[cfg(all(debug_assertions, feature = "std"))] {
+        pub(crate) fn test_toggle(id: &str, detected: bool) -> bool {
+            if std::env::var(alloc::format!("GRAVIOLA_CPU_DISABLE_{id}")).is_ok() {
+                std::println!("DEBUG: denying cpuid {id:?}");
+                false
+            } else {
+                detected
+            }
+        }
     } else {
-        detected
+        pub(crate) fn test_toggle(_id: &str, detected: bool) -> bool {
+            detected
+        }
     }
 }
 
@@ -252,7 +261,7 @@ pub(crate) fn verify_cpu_features() {
 
     // assorted intrinsic code
     assert!(
-        is_x86_feature_detected!("avx"),
+        have_cpu_feature!("avx"),
         "graviola requires avx CPU support"
     );
     assert!(

--- a/graviola/src/low/x86_64/ghash.rs
+++ b/graviola/src/low/x86_64/ghash.rs
@@ -474,7 +474,7 @@ mod tests {
     }
 
     fn check(key: u128, input: &[u8]) {
-        println!("check: input={input:02x?}");
+        std::println!("check: input={input:02x?}");
         let ta = GhashTable::new(key);
         let tb = model::GhashTable::new(key);
         let mut a = Ghash::new(&ta);

--- a/graviola/src/mid/aes_gcm.rs
+++ b/graviola/src/mid/aes_gcm.rs
@@ -138,6 +138,7 @@ impl AesGcm {
 mod tests {
     use super::*;
     use crate::test::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn smoketest() {
@@ -194,7 +195,7 @@ mod tests {
 
             fn on_value(&mut self, name: &str, value: Value<'_>) {
                 match name {
-                    "Count" => println!("  test {}", value.int()),
+                    "Count" => std::println!("  test {}", value.int()),
                     "Key" => self.key = Some(AesGcm::new(&value.bytes())),
                     "IV" => self.nonce = value.bytes(),
                     "CT" => self.ct = value.bytes(),
@@ -202,7 +203,7 @@ mod tests {
                     "Tag" if !self.encrypt => self.tag = value.bytes(),
                     "Tag" if self.encrypt => {
                         if self.nonce.len() != 12 {
-                            println!("skip unhandled nonce len");
+                            std::println!("skip unhandled nonce len");
                             return;
                         }
                         let mut got_tag = [0u8; 16];
@@ -219,7 +220,7 @@ mod tests {
                     "FAIL" => {
                         assert!(!self.encrypt);
                         if self.nonce.len() != 12 {
-                            println!("skip unhandled nonce len");
+                            std::println!("skip unhandled nonce len");
                             return;
                         }
                         assert_eq!(
@@ -238,7 +239,7 @@ mod tests {
                     }
                     "PT" if !self.encrypt => {
                         if self.nonce.len() != 12 || self.tag.len() != 16 {
-                            println!("skip unhandled nonce/tag len");
+                            std::println!("skip unhandled nonce/tag len");
                             return;
                         }
                         self.key

--- a/graviola/src/mid/p256.rs
+++ b/graviola/src/mid/p256.rs
@@ -1105,9 +1105,10 @@ const CURVE_ORDER_MM: [u64; 4] = [
 
 #[cfg(test)]
 mod tests {
-    use core::mem::size_of_val;
-
     use super::*;
+    use alloc::format;
+    use core::mem::size_of_val;
+    use std::println;
 
     const CURVE_GENERATOR: AffineMontPoint = AffineMontPoint {
         xy: [

--- a/graviola/src/mid/p384.rs
+++ b/graviola/src/mid/p384.rs
@@ -942,9 +942,10 @@ const CURVE_ORDER_MM: [u64; 6] = [
 
 #[cfg(test)]
 mod tests {
-    use core::mem::size_of_val;
-
     use super::*;
+    use alloc::format;
+    use core::mem::size_of_val;
+    use std::println;
 
     const CURVE_GENERATOR: AffineMontPoint = AffineMontPoint {
         xy: [

--- a/graviola/src/mid/rsa_priv/generate.rs
+++ b/graviola/src/mid/rsa_priv/generate.rs
@@ -323,6 +323,7 @@ type MaxPosInt = PosInt<{ super::MAX_PRIVATE_MODULUS_WORDS }>;
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
     use core::time::Duration;
     use std::time::Instant;
 
@@ -343,7 +344,7 @@ mod tests {
 
     fn read_hex_lines_from_file(data: &str) -> impl Iterator<Item = Vec<u8>> + '_ {
         data.lines()
-            .inspect(|line| println!("Processing line: {line}"))
+            .inspect(|line| std::println!("Processing line: {line}"))
             .filter(|line| !line.starts_with("#"))
             .map(|line| {
                 (0..line.len())
@@ -377,7 +378,7 @@ mod tests {
     #[test]
     fn test_rsa_bench() {
         let bytes = read_hex_from_file(include_str!("../../testdata/rsa.bench.2048.txt"));
-        let mut results = vec![];
+        let mut results = alloc::vec![];
 
         for _ in 0..32 {
             let mut candidate_source = SliceRandomSource(&bytes);
@@ -387,7 +388,7 @@ mod tests {
             generate_key(KeySize::Rsa2048, &mut candidate_source, &mut witness_source).unwrap();
             results.push(start.elapsed());
         }
-        println!(
+        std::println!(
             "Results: min={}ns, mean={}ns, max={}ns",
             results.iter().min().unwrap().as_nanos(),
             results.iter().sum::<Duration>().as_nanos() / results.len() as u128,

--- a/graviola/src/mid/rsa_pub.rs
+++ b/graviola/src/mid/rsa_pub.rs
@@ -94,6 +94,7 @@ type RsaPosInt = low::PosInt<MAX_PUBLIC_MODULUS_WORDS>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::println;
 
     #[test]
     fn smoke() {

--- a/graviola/src/mid/sha2.rs
+++ b/graviola/src/mid/sha2.rs
@@ -224,6 +224,7 @@ impl Sha512Context {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn hello() {

--- a/graviola/src/test.rs
+++ b/graviola/src/test.rs
@@ -1,6 +1,8 @@
 // Written for Graviola by Joe Birr-Pixton, 2024.
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
 
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -52,7 +54,7 @@ pub(crate) fn process_cavp(filename: impl AsRef<Path>, sink: &mut dyn CavpSink) 
                 continue;
             }
             Some('#') => {
-                println!("{line}");
+                std::println!("{line}");
                 continue;
             }
             None => continue,


### PR DESCRIPTION
One of the things that `#![no_std]` implies is that the prelude is no longer available, thus the `std::` prefixes.