### PR TITLE
Enable debug symbols in benchmark builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ members = [
 
 [profile.bench]
 lto = "thin"
+debug = true


### PR DESCRIPTION
This enables CPU profilers to show function- and line-level data.