### PR TITLE
impl Debug for SigningKeys

### DIFF
--- a/graviola/src/high/ecdsa.rs
+++ b/graviola/src/high/ecdsa.rs
@@ -255,6 +255,12 @@ impl<C: Curve> SigningKey<C> {
     }
 }
 
+impl<C: Curve> core::fmt::Debug for SigningKey<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SigningKey").finish()
+    }
+}
+
 /// An ECDSA verification key, on curve `C`.
 pub struct VerifyingKey<C: Curve> {
     /// The public key.

--- a/graviola/src/high/ed25519.rs
+++ b/graviola/src/high/ed25519.rs
@@ -165,6 +165,12 @@ impl Ed25519SigningKey {
     }
 }
 
+impl core::fmt::Debug for Ed25519SigningKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Ed25519SigningKey").finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/graviola/src/high/rsa.rs
+++ b/graviola/src/high/rsa.rs
@@ -546,6 +546,12 @@ impl SigningKey {
     }
 }
 
+impl core::fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SigningKey").finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Doesn't expose sensitive fields.

`aws-lc-rs` implements Debug for signing keys -> https://docs.rs/aws-lc-rs/latest/aws_lc_rs/signature/struct.EcdsaKeyPair.html

`ring` implements Debug for signing keys -> https://docs.rs/ring/latest/ring/signature/struct.EcdsaKeyPair.html

`rust-crypto` implements Debug for signing keys -> https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html