### PR TITLE
Rework ctgrind/valgrind interaction

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -24,7 +24,7 @@ jobs:
           toolchain: "1.89"
 
       - name: Check MSRV
-        run: cargo build --lib --all-features
+        run: cargo build --lib
 
   lints:
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           components: rustfmt
 
       - name: clippy
-        run: cargo +stable clippy --all-features --all-targets -- --deny warnings
+        run: cargo +stable clippy --all-targets -- --deny warnings
 
       - name: rustfmt
         run: cargo +stable fmt --check

--- a/admin/coverage
+++ b/admin/coverage
@@ -6,7 +6,7 @@ cargo llvm-cov show-env --export-prefix "$@" > envsh
 source ./envsh
 cargo llvm-cov clean --workspace
 
-env SLOW_TESTS=1 cargo test --locked --all-features
+env SLOW_TESTS=1 cargo test --locked
 
 if [ `uname -p` == "x86_64" ] ; then
     env GRAVIOLA_CPU_DISABLE_sha=1 GRAVIOLA_CPU_DISABLE_bmi2=1 GRAVIOLA_CPU_DISABLE_avx512bw=1 GRAVIOLA_CPU_DISABLE_avx512f=1 GRAVIOLA_CPU_DISABLE_vaes=1 cargo test --locked

--- a/admin/ctgrind
+++ b/admin/ctgrind
@@ -1,9 +1,8 @@
 #!/bin/sh
 set -e
 
-# ensure tests are built: cargo and rustc are not valgrind-friendly
-cargo test --no-run "$@"
+export VALGRIND_BUG_494162=1
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --track-origins=yes"
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --track-origins=yes"
 
-# nb. do not run zeroing test, it is extremely valgrind-unfriendly
-valgrind --trace-children=yes --track-origins=yes \
-    cargo test --lib --test wycheproof "$@"
+cargo test --lib --test wycheproof --features __ctgrind "$@"

--- a/graviola/Cargo.toml
+++ b/graviola/Cargo.toml
@@ -11,10 +11,12 @@ rust-version = "1.89"
 
 [features]
 default = []
+__ctgrind = ["dep:crabgrind"]
 
 [dependencies]
 cfg-if = "1"
 getrandom = "0.3"
+crabgrind = { version = "=0.1.9", optional = true }
 
 [dev-dependencies]
 aws-lc-rs = { version = "1.16", default-features = false, features = ["alloc", "prebuilt-nasm", "non-fips"] }
@@ -23,6 +25,3 @@ proptest = "1.5.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3.24.0"
-
-[target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))'.dev-dependencies]
-crabgrind = "=0.1.9" # compatible with valgrind package on GHA ubuntu-latest

--- a/graviola/src/low/ct.rs
+++ b/graviola/src/low/ct.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
 
 cfg_if::cfg_if! {
-    if #[cfg(all(test, target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))] {
+    if #[cfg(all(test, feature = "__ctgrind"))] {
         use crabgrind as cg;
         use core::mem::size_of_val;
 


### PR DESCRIPTION
- Use a cargo feature rather than platforms
- Use `CARGO_*_RUNNER` to invoke valgrind

fixes #154