### PR TITLE
Do fewer iterations in rsa_bench when running ctgrind tests.

### DIFF
--- a/graviola/src/mid/rsa_priv/generate.rs
+++ b/graviola/src/mid/rsa_priv/generate.rs
@@ -379,7 +379,14 @@ mod tests {
         let bytes = read_hex_from_file(include_str!("../../testdata/rsa.bench.2048.txt"));
         let mut results = vec![];
 
-        for _ in 0..32 {
+        // If running under Valgrind, which is slow, do fewer iterations.
+        #[cfg(feature = "__ctgrind")]
+        const NUM_ITERATIONS: usize = 1;
+
+        #[cfg(not(feature = "__ctgrind"))]
+        const NUM_ITERATIONS: usize = 32;
+
+        for _ in 0..NUM_ITERATIONS {
             let mut candidate_source = SliceRandomSource(&bytes);
             let mut witness_source = SystemRandom;
 


### PR DESCRIPTION
This test takes a long time under Valgrind, so the number of iterations is reduced to one to speed it up.