### PR TITLE
Enable the parse-asm scripts to work on macOS

### DIFF
--- a/admin/parse-asm/all.sh
+++ b/admin/parse-asm/all.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 for d in driver.*.py ; do
-  python $d
+  python3 $d
 done


### PR DESCRIPTION
Tested successfully on macOS 26.5.1/aarch64 using the python3 from Homebrew (the Python version shipped with macOS was missing the needed `StrEnum` type) and the cross-compilation toolchains from https://github.com/messense/homebrew-macos-cross-toolchains