### PR TITLE
Test Cranelift support in CI

### DIFF
--- a/.github/workflows/cranelift.yml
+++ b/.github/workflows/cranelift.yml
@@ -1,0 +1,57 @@
+name: cranelift
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 18 * * *"
+
+env:
+  CARGO_TERM_COLOR: "always"
+  CARGO_UNSTABLE_CODEGEN_BACKEND: "true"
+  CARGO_PROFILE_DEV_CODEGEN_BACKEND: "cranelift"
+  CARGO_PROFILE_RELEASE_CODEGEN_BACKEND: "cranelift"
+  # Cranelift doesn't support unwinding: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1567
+  CARGO_UNSTABLE_PANIC_ABORT_TESTS: "true"
+  CARGO_PROFILE_DEV_PANIC: "abort"
+  CARGO_PROFILE_RELEASE_PANIC: "abort"
+  # Cranelift lacks AVX-512 intrinsics
+  GRAVIOLA_CPU_DISABLE_avx512f: "1"
+  GRAVIOLA_CPU_DISABLE_avx512bw: "1"
+  GRAVIOLA_CPU_DISABLE_avx512vl: "1"
+  # Fix AWS LC linking: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1520
+  AWS_LC_SYS_NO_U1_BINDINGS: "1"
+
+jobs:
+  cranelift:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rustc-codegen-cranelift
+
+      - name: Build (debug)
+        run: cargo build -p graviola
+      - name: Run tests (debug)
+        run: cargo test
+      - name: Run tests (debug, --no-default-features)
+        run: cargo test --no-default-features
+
+      - name: Build (release)
+        run: cargo build -p graviola --release
+      - name: Run tests (release)
+        run: env SLOW_TESTS=1 cargo test --release

--- a/graviola/src/low/aarch64/aes.rs
+++ b/graviola/src/low/aarch64/aes.rs
@@ -38,6 +38,14 @@ impl AesKey {
     }
 }
 
+impl Drop for AesKey {
+    fn drop(&mut self) {
+        low::zeroise_value(self);
+    }
+}
+
+impl low::generic::zeroise::Zeroable for AesKey {}
+
 pub(crate) struct AesKey128 {
     round_keys: [uint8x16_t; 10 + 1],
 }
@@ -76,12 +84,6 @@ impl AesKey128 {
 
     pub(crate) fn round_keys(&self) -> &[uint8x16_t; 11] {
         &self.round_keys
-    }
-}
-
-impl Drop for AesKey128 {
-    fn drop(&mut self) {
-        low::zeroise(&mut self.round_keys);
     }
 }
 
@@ -131,12 +133,6 @@ impl AesKey256 {
 
     pub(crate) fn round_keys(&self) -> &[uint8x16_t; 15] {
         &self.round_keys
-    }
-}
-
-impl Drop for AesKey256 {
-    fn drop(&mut self) {
-        low::zeroise(&mut self.round_keys);
     }
 }
 
@@ -378,6 +374,7 @@ pub(crate) fn _aes256_8_blocks(
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    #[cfg(panic = "unwind")]
     use std::panic;
 
     use super::*;

--- a/graviola/src/low/x86_64/aes.rs
+++ b/graviola/src/low/x86_64/aes.rs
@@ -90,6 +90,14 @@ impl AesKey {
     }
 }
 
+impl Drop for AesKey {
+    fn drop(&mut self) {
+        low::zeroise_value(self);
+    }
+}
+
+impl low::generic::zeroise::Zeroable for AesKey {}
+
 #[expect(clippy::large_enum_variant)] // 200 bytes is a bad heuristic for large enums
 pub(crate) enum RoundKeys512 {
     Aes128([__m512i; 11]),
@@ -127,12 +135,6 @@ impl AesKey128 {
     }
 }
 
-impl Drop for AesKey128 {
-    fn drop(&mut self) {
-        low::zeroise(&mut self.round_keys);
-    }
-}
-
 fn zero() -> __m128i {
     // SAFETY: this crate requires the `avx` cpu feature
     unsafe { _mm_setzero_si128() }
@@ -157,12 +159,6 @@ impl AesKey256 {
     pub(crate) fn encrypt_block(&self, inout: &mut [u8; 16]) {
         // SAFETY: this crate requires the `aes` & `avx` cpu features
         unsafe { aes256_block(&self.round_keys, inout) }
-    }
-}
-
-impl Drop for AesKey256 {
-    fn drop(&mut self) {
-        low::zeroise(&mut self.round_keys);
     }
 }
 
@@ -319,6 +315,7 @@ fn aes256_block(round_keys: &[__m128i; 15], block_inout: &mut [u8; 16]) {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    #[cfg(panic = "unwind")]
     use std::panic;
 
     use super::*;

--- a/graviola/src/low/x86_64/aes_gcm.rs
+++ b/graviola/src/low/x86_64/aes_gcm.rs
@@ -499,7 +499,7 @@ mod tests {
     fn check_counter512() {
         use super::*;
 
-        if !is_x86_feature_detected!("avx512f") {
+        if HaveAvx512ForAesGcm::check().is_none() {
             println!("no AVX512 support");
             return;
         }

--- a/rustls-graviola/src/sign.rs
+++ b/rustls-graviola/src/sign.rs
@@ -315,6 +315,7 @@ impl fmt::Debug for Ed25519 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(panic = "unwind")]
     use std::panic;
 
     use graviola::signing::ecdsa;


### PR DESCRIPTION
Resolves #127

With the removal of `libcrux` (and some added intrinsics upstream), Cranelift should run fine now.

This did highlight a behavioral difference around AES zeroing. Moving the zeroing to the wrapper enum seemed to resolve it.

<details>

<summary>Failure test output</summary>

```
  test aes_gcm ... FAILED

  failures:

  ---- aes_gcm stdout ----
  this value is 512 bytes in length
  before_drop: [00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, e8, e9,
  e9, e9, 17, 16, 16, 16, e8, e9, e9, e9, 17, 16, 16, 16, ad, ae, ae, 19, ba, b8, b8, 0f, 52, 51, 51, e6, 45, 47, 47, f0, 09, 0e, 22, 77, b3, b6, 9a, 78,
  e1, e7, cb, 9e, a4, a0, 8c, 6e, e1, 6a, bd, 3e, 52, dc, 27, 46, b3, 3b, ec, d8, 17, 9b, 60, b6, e5, ba, f3, ce, b7, 66, d4, 88, 04, 5d, 38, 50, 13, c6,
  58, e6, 71, d0, 7d, b3, c6, b6, a9, 3b, c2, eb, 91, 6b, d1, 2d, c9, 8d, e9, 0d, 20, 8d, 2f, bb, 89, b6, ed, 50, 18, dd, 3c, 7d, d1, 50, 96, 33, 73, 66,
  b9, 88, fa, d0, 54, d8, e2, 0d, 68, a5, 33, 5d, 8b, f0, 3f, 23, 32, 78, c5, f3, 66, a0, 27, fe, 0e, 05, 14, a3, d6, 0a, 35, 88, e4, 72, f0, 7b, 82, d2,
  d7, 85, 8c, d7, c3, 26, 00, 00, 00, 00, 00, 00, 00, 00, 00, a0, ff, f7, ff, 7f, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, f8, fa, fe, ff, ff, 7f, 00, 00,
  f0, ec, ff, f7, ff, 7f, 00, 00, 40, d3, ff, f7, ff, 7f, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, a0, ff, f7, ff, 7f, 00, 00, 59, 92, 7f, 71, 8a, 90,
  c8, 12, 9b, bf, fa, 0e, 19, 4b, ec, 81, d6, 54, 10, 5e, c4, 8d, bf, 92, b6, 71, 07, e1, 80, 30, c0, 32, d9, 5c, 8f, 07, b7, a3, 07, aa, 97, e6, b2, ef,
  02, bf, f9, 47, 6d, 08, ff, 08, d7, a9, 88, 69, bc, 4e, ed, 1f, 20, 2e, 11, 42, 51, a2, 87, 40, be, d3, 86, 74, 3a, 8a, 7e, e6, 98, 90, 05, 4d, 06, 8c,
  9a, 23, ee, df, 4f, be, 54, bc, db, d8, 5b, dd, ee, 14, 48, bb, 18, 25, 22, 7d, f0, e8, be, 10, af, 4e, 35, e6, 5f, f0, 15, de, 24, 7a, 51, be, 25, eb,
  78, 2b, ad, f3, f1, 33, 19, 40, c2, 2d, 85, 7f, 93, db, 24, 93, c2, 2d, 85, 7f, 93, db, 24, 93, 60, 25, 17, bf, 44, bd, 7f, a0, 60, 25, 17, bf, 44, bd,
  7f, a0, 4e, ba, 3d, e8, b5, 1c, fe, ed, 4e, ba, 3d, e8, b5, 1c, fe, ed, d1, 46, 12, 17, f7, 87, 99, 2b, d1, 46, 12, 17, f7, 87, 99, 2b, 6b, 28, f9, a6,
  26, 43, 83, 39, 6b, 28, f9, a6, 26, 43, 83, 39, 52, 30, 41, fb, b5, 02, a1, aa, 52, 30, 41, fb, b5, 02, a1, aa, f6, ab, b7, 6b, 17, 9b, af, 18, f6, ab,
  b7, 6b, 17, 9b, af, 18, 6d, f5, 89, 89, a0, 8d, 3c, ab, 6d, f5, 89, 89, a0, 8d, 3c, ab]
  after_drop: [00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, a0, ff,
  f7, ff, 7f, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, f8, fa, fe, ff, ff, 7f, 00, 00, f0, ec, ff, f7, ff, 7f, 00, 00, 40, d3, ff, f7, ff, 7f, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, a0, ff, f7, ff, 7f, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
  00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
  ---- aes_gcm stderr ----

  thread 'main' (1485771) panicked at graviola/tests/zeroing.rs:153:13:
  byte 201 (0xa0) was not cleared after drop


  failures:
      aes_gcm
```

</details>