### PR TITLE
Improve ML-KEM performance with by-4 SHAKE128 and by-6 SHAKE256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graviola"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aws-lc-rs",
  "cfg-if",

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ encapsulation and decapsulation) is written in Rust.
 Compression and decompression are division-free, avoiding the variable-time
 division behind the KyberSlash attacks.
 
+We achieve good performance by using a 4-wide Keccak-f permutation for
+`SampleNTT()` and `SamplePolyCBD()`.  On x86-64 this uses an AVX2 4-wide
+implementation, on aarch64 it uses a Neon+SHA3 2-wide implementation twice
+(for a bit of mechanical sympathy with ARM's limited vector size).
+
 ### Symmetric cryptography
 SHA256 has straightforward implementations using hashing intrinsics
 (aka "SHA-NI" on x86_64, "sha" extension on aarch64) with runtime fallback

--- a/admin/parse-asm/driver.sha3.py
+++ b/admin/parse-asm/driver.sha3.py
@@ -22,6 +22,23 @@ if __name__ == "__main__":
         parse_file(input, d)
 
     with (
+        open("../../thirdparty/s2n-bignum/x86/sha3/sha3_keccak4_f1600_alt.S") as input,
+        open("../../graviola/src/low/x86_64/sha3_keccak4_f1600_alt.rs", "w") as output,
+    ):
+        d = RustDriver(output, Architecture_amd64)
+        d.emit_rust_function(
+            "sha3_keccak4_f1600_alt",
+            parameter_map=[
+                ("inout", "a.as_mut_ptr() => _"),
+                ("inout", "rc.as_ptr() => _"),
+                ("inout", "rho8.as_ptr() => _"),
+                ("inout", "rho56.as_ptr() => _"),
+            ],
+            rust_decl="fn sha3_keccak4_f1600(a: &mut [[u64; 25]; 4], rc: &[u64; 24], rho8: &[u64; 4], rho56: &[u64; 4])",
+        )
+        parse_file(input, d)
+
+    with (
         open("../../thirdparty/s2n-bignum/arm/sha3/sha3_keccak_f1600.S") as input,
         open("../../graviola/src/low/aarch64/sha3_keccak_f1600.rs", "w") as output,
     ):
@@ -49,5 +66,21 @@ if __name__ == "__main__":
             ],
             func_attrs='#[target_feature(enable = "sha3")]\n',
             rust_decl="unsafe fn sha3_keccak_f1600(a: &mut [u64; 25], rc: &[u64; 24])",
+        )
+        parse_file(input, d)
+
+    with (
+        open("../../thirdparty/s2n-bignum/arm/sha3/sha3_keccak2_f1600.S") as input,
+        open("../../graviola/src/low/aarch64/sha3_keccak2_f1600.rs", "w") as output,
+    ):
+        d = RustDriver(output, Architecture_aarch64)
+        d.emit_rust_function(
+            "sha3_keccak2_f1600",
+            parameter_map=[
+                ("inout", "a.as_mut_ptr() => _"),
+                ("inout", "rc.as_ptr() => _"),
+            ],
+            func_attrs='#[target_feature(enable = "sha3")]\n',
+            rust_decl="fn sha3_keccak2_f1600(a: &mut [[u64; 25]; 2], rc: &[u64; 24])",
         )
         parse_file(input, d)

--- a/admin/parse-asm/parse.py
+++ b/admin/parse-asm/parse.py
@@ -11,7 +11,7 @@ from cpp import Preprocessor
 
 MACRO = re.compile(r"^(?P<name>[a-z0-9_]+)\((?P<args>[a-z0-9_,\[\]\+\* \#]*)\);?$")
 ASM = re.compile(
-    r"^(?P<opcode>[a-z][a-z0-9\.]*)\s?(?P<operands>[A-Za-z0-9_,\s\(\)\[\]{}\+\*\-~\t#\.!%$@]*) ?;? ?(//(?P<comment>[A-Za-z0-9 =\/@#\*\+\(\)^\.\<\>\-_:,\!\?\|])*)?$"
+    r"^(?P<opcode>[a-z][a-z0-9\.]*)\s?(?P<operands>[A-Za-z0-9_,\s\(\)\[\]{}\+\*\-~\t#\.!%$@]*) ?;? ?(//(?P<comment>[A-Za-z0-9 =\/@#\*\+\(\)^\.\<\>\-_:,\!\?\|%\[\]'])*)?$"
 )
 CONST = re.compile(r"\s?(?P<type>\.(quad|long))\s+(?P<value>((0x[0-9a-fA-F]+),?)+)")
 LABEL = re.compile(r"^(?P<name>(\.L)?[a-zA-Z0-9_]+):$")

--- a/graviola/Cargo.toml
+++ b/graviola/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graviola"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 repository = "https://github.com/ctz/graviola/"
 license = "Apache-2.0 OR ISC OR MIT-0"

--- a/graviola/src/low/aarch64/mod.rs
+++ b/graviola/src/low/aarch64/mod.rs
@@ -77,6 +77,7 @@ pub(crate) mod p384_montjadd;
 pub(crate) mod p384_montjdouble;
 pub(crate) mod sha256;
 pub(crate) mod sha3_keccak2_f1600;
+pub(crate) mod sha3_keccak2of4_f1600;
 pub(crate) mod sha3_keccak4_f1600_mux;
 pub(crate) mod sha3_keccak_f1600;
 pub(crate) mod sha3_keccak_f1600_alt;

--- a/graviola/src/low/aarch64/mod.rs
+++ b/graviola/src/low/aarch64/mod.rs
@@ -76,6 +76,8 @@ pub(crate) mod p256_montjmixadd;
 pub(crate) mod p384_montjadd;
 pub(crate) mod p384_montjdouble;
 pub(crate) mod sha256;
+pub(crate) mod sha3_keccak2_f1600;
+pub(crate) mod sha3_keccak4_f1600_mux;
 pub(crate) mod sha3_keccak_f1600;
 pub(crate) mod sha3_keccak_f1600_alt;
 pub(crate) mod sha3_keccak_f1600_mux;

--- a/graviola/src/low/aarch64/sha3_keccak2_f1600.rs
+++ b/graviola/src/low/aarch64/sha3_keccak2_f1600.rs
@@ -1,0 +1,293 @@
+// generated source. do not edit.
+#![allow(non_upper_case_globals, unused_macros, unused_imports)]
+use crate::low::macros::*;
+
+// Copyright (c) 2024 The mlkem-native project authors
+// Copyright (c) 2021-2022 Arm Limited
+// Copyright (c) 2022 Matthias Kannwischer
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+// ----------------------------------------------------------------------------
+// Keccak-f1600 permutation for SHA3, batch of two independent operations
+// Input a[50], rc[24]; output a[50]
+//
+// The input/output argument is in effect two 25-element Keccak arrays
+// a[0...24] and a[25..49], which could be considered as type a[25][2].
+//
+// Thinking of each such input/output array as a row-major flattening of a
+// 5x5 matrix of 64-bit words, this performs the Keccak-f1600 permutation,
+// all 24 rounds with the distinct round constants rc[i] for each one. For
+// correct operation, the input pointer rc should point at the standard
+// round constants as in the specification:
+//
+//   https://keccak.team/keccak_specs_summary.html#roundConstants
+//
+// This operation is at the core of SHA3 and is fully specified here:
+//
+//   https://keccak.team/files/Keccak-reference-3.0.pdf
+//
+// extern void sha3_keccak2_f1600(uint64_t a[static 50],
+//                                const uint64_t rc[static 24]);
+//
+// Standard ARM ABI: X0 = a, X1 = rc
+// ----------------------------------------------------------------------------
+
+/// Keccak-f1600 permutation for SHA3, batch of two independent operations
+///
+/// Input a[50], rc[24]; output a[50]
+///
+/// The input/output argument is in effect two 25-element Keccak arrays
+/// a[0...24] and a[25..49], which could be considered as type a[25][2].
+///
+/// Thinking of each such input/output array as a row-major flattening of a
+/// 5x5 matrix of 64-bit words, this performs the Keccak-f1600 permutation,
+/// all 24 rounds with the distinct round constants rc[i] for each one. For
+/// correct operation, the input pointer rc should point at the standard
+/// round constants as in the specification:
+///
+///   https://keccak.team/keccak_specs_summary.html#roundConstants
+///
+/// This operation is at the core of SHA3 and is fully specified here:
+///
+///   https://keccak.team/files/Keccak-reference-3.0.pdf
+#[target_feature(enable = "sha3")]
+pub(crate) fn sha3_keccak2_f1600(a: &mut [[u64; 25]; 2], rc: &[u64; 24]) {
+    // SAFETY: inline assembly. see [crate::low::inline_assembly_safety] for safety info.
+    unsafe {
+        core::arch::asm!(
+
+        // This is similar to the code in the mlkem-native repository here:
+        //
+        //   mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
+        //
+        // The main difference is the avoidance of ld2/st2 in favour of explicit
+        // transposition operations and conventional loads and stores.
+
+        Q!("    sub             " "sp, sp, # (64 + 0)"),
+        Q!("    stp             " "d8, d9, [sp, # (0 + 0)]"),
+        Q!("    stp             " "d10, d11, [sp, # (16 + 0)]"),
+        Q!("    stp             " "d12, d13, [sp, # (32 + 0)]"),
+        Q!("    stp             " "d14, d15, [sp, # (48 + 0)]"),
+
+        // Load the Keccak initial state into upper and lower parts of Q0..Q24
+
+        Q!("    add             " "x2, x0, #0xc8"),
+
+        Q!("    ldp             " "q24, q25, [x0]"),
+        Q!("    ldp             " "q26, q27, [x2]"),
+        Q!("    trn1            " "v0.2d, v24.2d, v26.2d"),
+        Q!("    trn2            " "v1.2d, v24.2d, v26.2d"),
+        Q!("    trn1            " "v2.2d, v25.2d, v27.2d"),
+        Q!("    trn2            " "v3.2d, v25.2d, v27.2d"),
+
+        Q!("    ldp             " "q24, q25, [x0, #0x20]"),
+        Q!("    ldp             " "q26, q27, [x2, #0x20]"),
+        Q!("    trn1            " "v4.2d, v24.2d, v26.2d"),
+        Q!("    trn2            " "v5.2d, v24.2d, v26.2d"),
+        Q!("    trn1            " "v6.2d, v25.2d, v27.2d"),
+        Q!("    trn2            " "v7.2d, v25.2d, v27.2d"),
+
+        Q!("    ldp             " "q24, q25, [x0, #0x40]"),
+        Q!("    ldp             " "q26, q27, [x2, #0x40]"),
+        Q!("    trn1            " "v8.2d, v24.2d, v26.2d"),
+        Q!("    trn2            " "v9.2d, v24.2d, v26.2d"),
+        Q!("    trn1            " "v10.2d, v25.2d, v27.2d"),
+        Q!("    trn2            " "v11.2d, v25.2d, v27.2d"),
+
+        Q!("    ldp             " "q24, q25, [x0, #0x60]"),
+        Q!("    ldp             " "q26, q27, [x2, #0x60]"),
+        Q!("    trn1            " "v12.2d, v24.2d, v26.2d"),
+        Q!("    trn2            " "v13.2d, v24.2d, v26.2d"),
+        Q!("    trn1            " "v14.2d, v25.2d, v27.2d"),
+        Q!("    trn2            " "v15.2d, v25.2d, v27.2d"),
+
+        Q!("    ldp             " "q24, q25, [x0, #0x80]"),
+        Q!("    ldp             " "q26, q27, [x2, #0x80]"),
+        Q!("    trn1            " "v16.2d, v24.2d, v26.2d"),
+        Q!("    trn2            " "v17.2d, v24.2d, v26.2d"),
+        Q!("    trn1            " "v18.2d, v25.2d, v27.2d"),
+        Q!("    trn2            " "v19.2d, v25.2d, v27.2d"),
+
+        Q!("    ldp             " "q24, q25, [x0, #0xa0]"),
+        Q!("    ldp             " "q26, q27, [x2, #0xa0]"),
+        Q!("    trn1            " "v20.2d, v24.2d, v26.2d"),
+        Q!("    trn2            " "v21.2d, v24.2d, v26.2d"),
+        Q!("    trn1            " "v22.2d, v25.2d, v27.2d"),
+        Q!("    trn2            " "v23.2d, v25.2d, v27.2d"),
+
+        Q!("    ldr             " "d24, [x0, #0xc0]"),
+        Q!("    ldr             " "d25, [x2, #0xc0]"),
+        Q!("    trn1            " "v24.2d, v24.2d, v25.2d"),
+
+        // Now 24 rounds of the iteration
+
+        Q!("    mov             " "x2, #24"),
+
+        Q!(Label!("Lsha3_keccak2_f1600_loop", 2) ":"),
+        Q!("    eor3            " "v30.16b, v0.16b, v5.16b, v10.16b"),
+        Q!("    eor3            " "v29.16b, v1.16b, v6.16b, v11.16b"),
+        Q!("    eor3            " "v28.16b, v2.16b, v7.16b, v12.16b"),
+        Q!("    eor3            " "v27.16b, v3.16b, v8.16b, v13.16b"),
+        Q!("    eor3            " "v26.16b, v4.16b, v9.16b, v14.16b"),
+        Q!("    eor3            " "v30.16b, v30.16b, v15.16b, v20.16b"),
+        Q!("    eor3            " "v29.16b, v29.16b, v16.16b, v21.16b"),
+        Q!("    eor3            " "v28.16b, v28.16b, v17.16b, v22.16b"),
+        Q!("    eor3            " "v27.16b, v27.16b, v18.16b, v23.16b"),
+        Q!("    eor3            " "v26.16b, v26.16b, v19.16b, v24.16b"),
+        Q!("    rax1            " "v25.2d, v30.2d, v28.2d"),
+        Q!("    rax1            " "v28.2d, v28.2d, v26.2d"),
+        Q!("    rax1            " "v26.2d, v26.2d, v29.2d"),
+        Q!("    rax1            " "v29.2d, v29.2d, v27.2d"),
+        Q!("    rax1            " "v27.2d, v27.2d, v30.2d"),
+        Q!("    eor             " "v30.16b, v0.16b, v26.16b"),
+        Q!("    xar             " "v0.2d, v2.2d, v29.2d, #0x2"),
+        Q!("    xar             " "v2.2d, v12.2d, v29.2d, #0x15"),
+        Q!("    xar             " "v12.2d, v13.2d, v28.2d, #0x27"),
+        Q!("    xar             " "v13.2d, v19.2d, v27.2d, #0x38"),
+        Q!("    xar             " "v19.2d, v23.2d, v28.2d, #0x8"),
+        Q!("    xar             " "v23.2d, v15.2d, v26.2d, #0x17"),
+        Q!("    xar             " "v15.2d, v1.2d, v25.2d, #0x3f"),
+        Q!("    xar             " "v1.2d, v8.2d, v28.2d, #0x9"),
+        Q!("    xar             " "v8.2d, v16.2d, v25.2d, #0x13"),
+        Q!("    xar             " "v16.2d, v7.2d, v29.2d, #0x3a"),
+        Q!("    xar             " "v7.2d, v10.2d, v26.2d, #0x3d"),
+        Q!("    xar             " "v10.2d, v3.2d, v28.2d, #0x24"),
+        Q!("    xar             " "v3.2d, v18.2d, v28.2d, #0x2b"),
+        Q!("    xar             " "v18.2d, v17.2d, v29.2d, #0x31"),
+        Q!("    xar             " "v17.2d, v11.2d, v25.2d, #0x36"),
+        Q!("    xar             " "v11.2d, v9.2d, v27.2d, #0x2c"),
+        Q!("    xar             " "v9.2d, v22.2d, v29.2d, #0x3"),
+        Q!("    xar             " "v22.2d, v14.2d, v27.2d, #0x19"),
+        Q!("    xar             " "v14.2d, v20.2d, v26.2d, #0x2e"),
+        Q!("    xar             " "v20.2d, v4.2d, v27.2d, #0x25"),
+        Q!("    xar             " "v4.2d, v24.2d, v27.2d, #0x32"),
+        Q!("    xar             " "v24.2d, v21.2d, v25.2d, #0x3e"),
+        Q!("    xar             " "v21.2d, v5.2d, v26.2d, #0x1c"),
+        Q!("    xar             " "v27.2d, v6.2d, v25.2d, #0x14"),
+        Q!("    ld1r            " "{{ v31.2d }}, [x1], #8"),
+        Q!("    bcax            " "v5.16b, v10.16b, v7.16b, v11.16b"),
+        Q!("    bcax            " "v6.16b, v11.16b, v8.16b, v7.16b"),
+        Q!("    bcax            " "v7.16b, v7.16b, v9.16b, v8.16b"),
+        Q!("    bcax            " "v8.16b, v8.16b, v10.16b, v9.16b"),
+        Q!("    bcax            " "v9.16b, v9.16b, v11.16b, v10.16b"),
+        Q!("    bcax            " "v10.16b, v15.16b, v12.16b, v16.16b"),
+        Q!("    bcax            " "v11.16b, v16.16b, v13.16b, v12.16b"),
+        Q!("    bcax            " "v12.16b, v12.16b, v14.16b, v13.16b"),
+        Q!("    bcax            " "v13.16b, v13.16b, v15.16b, v14.16b"),
+        Q!("    bcax            " "v14.16b, v14.16b, v16.16b, v15.16b"),
+        Q!("    bcax            " "v15.16b, v20.16b, v17.16b, v21.16b"),
+        Q!("    bcax            " "v16.16b, v21.16b, v18.16b, v17.16b"),
+        Q!("    bcax            " "v17.16b, v17.16b, v19.16b, v18.16b"),
+        Q!("    bcax            " "v18.16b, v18.16b, v20.16b, v19.16b"),
+        Q!("    bcax            " "v19.16b, v19.16b, v21.16b, v20.16b"),
+        Q!("    bcax            " "v20.16b, v0.16b, v22.16b, v1.16b"),
+        Q!("    bcax            " "v21.16b, v1.16b, v23.16b, v22.16b"),
+        Q!("    bcax            " "v22.16b, v22.16b, v24.16b, v23.16b"),
+        Q!("    bcax            " "v23.16b, v23.16b, v0.16b, v24.16b"),
+        Q!("    bcax            " "v24.16b, v24.16b, v1.16b, v0.16b"),
+        Q!("    bcax            " "v0.16b, v30.16b, v2.16b, v27.16b"),
+        Q!("    bcax            " "v1.16b, v27.16b, v3.16b, v2.16b"),
+        Q!("    bcax            " "v2.16b, v2.16b, v4.16b, v3.16b"),
+        Q!("    bcax            " "v3.16b, v3.16b, v30.16b, v4.16b"),
+        Q!("    bcax            " "v4.16b, v4.16b, v27.16b, v30.16b"),
+        Q!("    eor             " "v0.16b, v0.16b, v31.16b"),
+        Q!("    sub             " "x2, x2, #0x1"),
+        Q!("    cbnz            " "x2, " Label!("Lsha3_keccak2_f1600_loop", 2, Before)),
+
+        // Store back the state
+
+        Q!("    add             " "x2, x0, #0xc8"),
+
+        Q!("    trn1            " "v25.2d, v0.2d, v1.2d"),
+        Q!("    trn1            " "v26.2d, v2.2d, v3.2d"),
+        Q!("    stp             " "q25, q26, [x0]"),
+        Q!("    trn2            " "v25.2d, v0.2d, v1.2d"),
+        Q!("    trn2            " "v26.2d, v2.2d, v3.2d"),
+        Q!("    stp             " "q25, q26, [x2]"),
+
+        Q!("    trn1            " "v25.2d, v4.2d, v5.2d"),
+        Q!("    trn1            " "v26.2d, v6.2d, v7.2d"),
+        Q!("    stp             " "q25, q26, [x0, #0x20]"),
+        Q!("    trn2            " "v25.2d, v4.2d, v5.2d"),
+        Q!("    trn2            " "v26.2d, v6.2d, v7.2d"),
+        Q!("    stp             " "q25, q26, [x2, #0x20]"),
+
+        Q!("    trn1            " "v25.2d, v8.2d, v9.2d"),
+        Q!("    trn1            " "v26.2d, v10.2d, v11.2d"),
+        Q!("    stp             " "q25, q26, [x0, #0x40]"),
+        Q!("    trn2            " "v25.2d, v8.2d, v9.2d"),
+        Q!("    trn2            " "v26.2d, v10.2d, v11.2d"),
+        Q!("    stp             " "q25, q26, [x2, #0x40]"),
+
+        Q!("    trn1            " "v25.2d, v12.2d, v13.2d"),
+        Q!("    trn1            " "v26.2d, v14.2d, v15.2d"),
+        Q!("    stp             " "q25, q26, [x0, #0x60]"),
+        Q!("    trn2            " "v25.2d, v12.2d, v13.2d"),
+        Q!("    trn2            " "v26.2d, v14.2d, v15.2d"),
+        Q!("    stp             " "q25, q26, [x2, #0x60]"),
+
+        Q!("    trn1            " "v25.2d, v16.2d, v17.2d"),
+        Q!("    trn1            " "v26.2d, v18.2d, v19.2d"),
+        Q!("    stp             " "q25, q26, [x0, #0x80]"),
+        Q!("    trn2            " "v25.2d, v16.2d, v17.2d"),
+        Q!("    trn2            " "v26.2d, v18.2d, v19.2d"),
+        Q!("    stp             " "q25, q26, [x2, #0x80]"),
+
+        Q!("    trn1            " "v25.2d, v20.2d, v21.2d"),
+        Q!("    trn1            " "v26.2d, v22.2d, v23.2d"),
+        Q!("    stp             " "q25, q26, [x0, #0xa0]"),
+        Q!("    trn2            " "v25.2d, v20.2d, v21.2d"),
+        Q!("    trn2            " "v26.2d, v22.2d, v23.2d"),
+        Q!("    stp             " "q25, q26, [x2, #0xa0]"),
+
+        Q!("    str             " "d24, [x0, #0xc0]"),
+        Q!("    trn2            " "v24.2d, v24.2d, v24.2d"),
+        Q!("    str             " "d24, [x2, #0xc0]"),
+
+        // Restore registers and return
+
+        Q!("    ldp             " "d8, d9, [sp, # (0 + 0)]"),
+        Q!("    ldp             " "d10, d11, [sp, # (16 + 0)]"),
+        Q!("    ldp             " "d12, d13, [sp, # (32 + 0)]"),
+        Q!("    ldp             " "d14, d15, [sp, # (48 + 0)]"),
+        Q!("    add             " "sp, sp, # (64 + 0)"),
+        inout("x0") a.as_mut_ptr() => _,
+        inout("x1") rc.as_ptr() => _,
+        // clobbers
+        out("v0") _,
+        out("v1") _,
+        out("v10") _,
+        out("v11") _,
+        out("v12") _,
+        out("v13") _,
+        out("v14") _,
+        out("v15") _,
+        out("v16") _,
+        out("v17") _,
+        out("v18") _,
+        out("v19") _,
+        out("v2") _,
+        out("v20") _,
+        out("v21") _,
+        out("v22") _,
+        out("v23") _,
+        out("v24") _,
+        out("v25") _,
+        out("v26") _,
+        out("v27") _,
+        out("v28") _,
+        out("v29") _,
+        out("v3") _,
+        out("v30") _,
+        out("v31") _,
+        out("v4") _,
+        out("v5") _,
+        out("v6") _,
+        out("v7") _,
+        out("v8") _,
+        out("v9") _,
+        out("x2") _,
+            )
+    };
+}

--- a/graviola/src/low/aarch64/sha3_keccak2of4_f1600.rs
+++ b/graviola/src/low/aarch64/sha3_keccak2of4_f1600.rs
@@ -1,0 +1,21 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+/// Compute Keccak-f1600 on the first two states in `a`.
+#[inline]
+pub(crate) fn sha3_keccak2of4_f1600(a: &mut [[u64; 25]; 4], rc: &[u64; 24]) {
+    let (a, _) = a.split_at_mut(2);
+    let a = a.try_into().unwrap();
+
+    match super::cpu::HaveSha3::check() {
+        // SAFETY: This branch is only called if the CPU has the SHA3 feature.
+        Some(_) => unsafe {
+            super::sha3_keccak2_f1600::sha3_keccak2_f1600(a, rc);
+        },
+        None => {
+            for a in a.iter_mut() {
+                super::sha3_keccak_f1600::sha3_keccak_f1600(a, rc);
+            }
+        }
+    }
+}

--- a/graviola/src/low/aarch64/sha3_keccak4_f1600_mux.rs
+++ b/graviola/src/low/aarch64/sha3_keccak4_f1600_mux.rs
@@ -1,0 +1,21 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+/// On my aarch64 computer, sha3_keccak2_f1600 is way more than 2x faster than
+/// sha3_keccak4_f1600.  So this function simply calls it twice.
+#[inline]
+pub(crate) fn sha3_keccak4_f1600(a: &mut [[u64; 25]; 4], rc: &[u64; 24]) {
+    match super::cpu::HaveSha3::check() {
+        // SAFETY: This branch is only called if the CPU has the SHA3 feature.
+        Some(_) => unsafe {
+            for a in a.as_chunks_mut().0.iter_mut() {
+                super::sha3_keccak2_f1600::sha3_keccak2_f1600(a, rc);
+            }
+        },
+        None => {
+            for a in a.iter_mut() {
+                super::sha3_keccak_f1600::sha3_keccak_f1600(a, rc);
+            }
+        }
+    }
+}

--- a/graviola/src/low/mod.rs
+++ b/graviola/src/low/mod.rs
@@ -123,6 +123,7 @@ cfg_if::cfg_if! {
         pub(crate) use x86_64::sha512_mux::sha512_compress_blocks;
         pub(crate) use x86_64::sha3_keccak_f1600::sha3_keccak_f1600;
         pub(crate) use x86_64::sha3_keccak4_f1600_shim::sha3_keccak4_f1600;
+        pub(crate) use x86_64::sha3_keccak2of4_f1600::sha3_keccak2of4_f1600;
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
 
@@ -200,6 +201,7 @@ cfg_if::cfg_if! {
         pub(crate) use aarch64::sha256::sha256_compress_blocks;
         pub(crate) use aarch64::sha3_keccak_f1600_mux::sha3_keccak_f1600;
         pub(crate) use aarch64::sha3_keccak4_f1600_mux::sha3_keccak4_f1600;
+        pub(crate) use aarch64::sha3_keccak2of4_f1600::sha3_keccak2of4_f1600;
 
         pub(crate) use generic::chacha20;
         pub(crate) use generic::sha512::sha512_compress_blocks;

--- a/graviola/src/low/mod.rs
+++ b/graviola/src/low/mod.rs
@@ -122,6 +122,7 @@ cfg_if::cfg_if! {
         pub(crate) use x86_64::sha256_mux::sha256_compress_blocks;
         pub(crate) use x86_64::sha512_mux::sha512_compress_blocks;
         pub(crate) use x86_64::sha3_keccak_f1600::sha3_keccak_f1600;
+        pub(crate) use x86_64::sha3_keccak4_f1600_shim::sha3_keccak4_f1600;
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
 
@@ -198,6 +199,7 @@ cfg_if::cfg_if! {
         pub(crate) use aarch64::p384_montjdouble::p384_montjdouble;
         pub(crate) use aarch64::sha256::sha256_compress_blocks;
         pub(crate) use aarch64::sha3_keccak_f1600_mux::sha3_keccak_f1600;
+        pub(crate) use aarch64::sha3_keccak4_f1600_mux::sha3_keccak4_f1600;
 
         pub(crate) use generic::chacha20;
         pub(crate) use generic::sha512::sha512_compress_blocks;

--- a/graviola/src/low/x86_64/mod.rs
+++ b/graviola/src/low/x86_64/mod.rs
@@ -79,6 +79,7 @@ pub(crate) mod p384_montjadd;
 pub(crate) mod p384_montjdouble;
 pub(crate) mod sha256;
 pub(crate) mod sha256_mux;
+pub(crate) mod sha3_keccak2of4_f1600;
 pub(crate) mod sha3_keccak4_f1600_alt;
 pub(crate) mod sha3_keccak4_f1600_shim;
 pub(crate) mod sha3_keccak_f1600;

--- a/graviola/src/low/x86_64/mod.rs
+++ b/graviola/src/low/x86_64/mod.rs
@@ -79,6 +79,8 @@ pub(crate) mod p384_montjadd;
 pub(crate) mod p384_montjdouble;
 pub(crate) mod sha256;
 pub(crate) mod sha256_mux;
+pub(crate) mod sha3_keccak4_f1600_alt;
+pub(crate) mod sha3_keccak4_f1600_shim;
 pub(crate) mod sha3_keccak_f1600;
 pub(crate) mod sha512;
 pub(crate) mod sha512_mux;

--- a/graviola/src/low/x86_64/sha3_keccak2of4_f1600.rs
+++ b/graviola/src/low/x86_64/sha3_keccak2of4_f1600.rs
@@ -1,0 +1,8 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+/// Compute Keccak-f1600 on the first two states in `a`.
+#[inline]
+pub(crate) fn sha3_keccak2of4_f1600(a: &mut [[u64; 25]; 4], rc: &[u64; 24]) {
+    super::sha3_keccak4_f1600_shim::sha3_keccak4_f1600(a, rc);
+}

--- a/graviola/src/low/x86_64/sha3_keccak4_f1600_alt.rs
+++ b/graviola/src/low/x86_64/sha3_keccak4_f1600_alt.rs
@@ -1,0 +1,682 @@
+// generated source. do not edit.
+#![allow(non_upper_case_globals, unused_macros, unused_imports)]
+use crate::low::macros::*;
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+// ----------------------------------------------------------------------------
+// Keccak-f1600 permutation for SHA3, batch of four independent operations
+// Input a[100], rc[24], rho8[4], rho56[4]; output a[100]
+//
+// The input/output argument is in effect four 25-element Keccak arrays
+// a[0...24], a[25..49], a[50..74] and a[75..99], which could be considered
+// as type a[25][4].
+//
+// Keccak-f1600 permutation operation is at the core of SHA3 and SHAKE
+// and is fully specified here:
+//
+//   https://keccak.team/files/Keccak-reference-3.0.pdf
+//
+//    extern void sha3_keccak4_f1600_alt(uint64_t a[100], const uint64_t rc[24], const uint64_t rho8[4], const uint64_t rho56[4]);
+//
+// Standard x86-64 ABI: RDI = a, RSI = rc, RDX = rho8, RCX = rho56
+// Microsoft x64 ABI:   RCX = a, RDX = rc, R8 = rho8, R9 = rho56
+// ----------------------------------------------------------------------------
+
+/// Keccak-f1600 permutation for SHA3, batch of four independent operations
+///
+/// Input a[100], rc[24], rho8[4], rho56[4]; output a[100]
+///
+/// The input/output argument is in effect four 25-element Keccak arrays
+/// a[0...24], a[25..49], a[50..74] and a[75..99], which could be considered
+/// as type a[25][4].
+///
+/// Keccak-f1600 permutation operation is at the core of SHA3 and SHAKE
+/// and is fully specified here:
+///
+///   https://keccak.team/files/Keccak-reference-3.0.pdf
+pub(crate) fn sha3_keccak4_f1600(
+    a: &mut [[u64; 25]; 4],
+    rc: &[u64; 24],
+    rho8: &[u64; 4],
+    rho56: &[u64; 4],
+) {
+    // SAFETY: inline assembly. see [crate::low::inline_assembly_safety] for safety info.
+    unsafe {
+        core::arch::asm!(
+
+        Q!("    endbr64         " ),
+
+        // **** Bitstates Allocation Map **** //
+        // 0x0(%rsp)     A[0]    [state0[0], state1[0], state2[0], state3[0]]     Input (%rdi) offsets: 0x00, 0xC8, 0x190, 0x258
+        // 0x20(%rsp)    A[1]    [state0[1], state1[1], state2[1], state3[1]]     Input (%rdi) offsets: 0x08, 0xD0, 0x198, 0x260
+        // 0x40(%rsp)    A[2]    [state0[2], state1[2], state2[2], state3[2]]     Input (%rdi) offsets: 0x10, 0xD8, 0x1A0, 0x268
+        // 0x60(%rsp)    A[3]    [state0[3], state1[3], state2[3], state3[3]]     Input (%rdi) offsets: 0x18, 0xE0, 0x1A8, 0x270
+        // 0x80(%rsp)    A[4]    [state0[4], state1[4], state2[4], state3[4]]     Input (%rdi) offsets: 0x20, 0xE8, 0x1B0, 0x278
+        // 0xa0(%rsp)    A[5]    [state0[5], state1[5], state2[5], state3[5]]     Input (%rdi) offsets: 0x28, 0xF0, 0x1B8, 0x280
+        // 0xc0(%rsp)    A[6]    [state0[6], state1[6], state2[6], state3[6]]     Input (%rdi) offsets: 0x30, 0xF8, 0x1C0, 0x288
+        // ymm10         A[7]    [state0[7], state1[7], state2[7], state3[7]]     Input (%rdi) offsets: 0x38, 0x100, 0x1C8, 0x290
+        // ymm14         A[8]    [state0[8], state1[8], state2[8], state3[8]]     Input (%rdi) offsets: 0x40, 0x108, 0x1D0, 0x298
+        // 0xe0(%rsp)    A[9]    [state0[9], state1[9], state2[9], state3[9]]     Input (%rdi) offsets: 0x48, 0x110, 0x1D8, 0x2A0
+        // 0x100(%rsp)   A[10]   [state0[10], state1[10], state2[10], state3[10]] Input (%rdi) offsets: 0x50, 0x118, 0x1E0, 0x2A8
+        // ymm8          A[11]   [state0[11], state1[11], state2[11], state3[11]] Input (%rdi) offsets: 0x58, 0x120, 0x1E8, 0x2B0
+        // ymm15         A[12]   [state0[12], state1[12], state2[12], state3[12]] Input (%rdi) offsets: 0x60, 0x128, 0x1F0, 0x2B8
+        // 0x120(%rsp)   A[13]   [state0[13], state1[13], state2[13], state3[13]] Input (%rdi) offsets: 0x68, 0x130, 0x1F8, 0x2C0
+        // 0x140(%rsp)   A[14]   [state0[14], state1[14], state2[14], state3[14]] Input (%rdi) offsets: 0x70, 0x138, 0x200, 0x2C8
+        // ymm9          A[15]   [state0[15], state1[15], state2[15], state3[15]] Input (%rdi) offsets: 0x78, 0x140, 0x208, 0x2D0
+        // 0x160(%rsp)   A[16]   [state0[16], state1[16], state2[16], state3[16]] Input (%rdi) offsets: 0x80, 0x148, 0x210, 0x2D8
+        // 0x180(%rsp)   A[17]   [state0[17], state1[17], state2[17], state3[17]] Input (%rdi) offsets: 0x88, 0x150, 0x218, 0x2E0
+        // ymm13         A[18]   [state0[18], state1[18], state2[18], state3[18]] Input (%rdi) offsets: 0x90, 0x158, 0x220, 0x2E8
+        // 0x1a0(%rsp)   A[19]   [state0[19], state1[19], state2[19], state3[19]] Input (%rdi) offsets: 0x98, 0x160, 0x228, 0x2F0
+        // 0x1c0(%rsp)   A[20]   [state0[20], state1[20], state2[20], state3[20]] Input (%rdi) offsets: 0xA0, 0x168, 0x230, 0x2F8
+        // ymm3          A[21]   [state0[21], state1[21], state2[21], state3[21]] Input (%rdi) offsets: 0xA8, 0x170, 0x238, 0x300
+        // ymm7          A[22]   [state0[22], state1[22], state2[22], state3[22]] Input (%rdi) offsets: 0xB0, 0x178, 0x240, 0x308
+        // 0x1e0(%rsp)   A[23]   [state0[23], state1[23], state2[23], state3[23]] Input (%rdi) offsets: 0xB8, 0x180, 0x248, 0x310
+        // ymm2          A[24]   [state0[24], state1[24], state2[24], state3[24]] Input (%rdi) offsets: 0xC0, 0x188, 0x250, 0x318
+
+        Q!("    mov             " "r11, rsp"),
+        Q!("    and             " "rsp, 0xffffffffffffffe0"),
+        Q!("    sub             " "rsp, 0x300"),
+
+        // Load 32 bytes from each of the 4 states (A[0-3])
+        Q!("    vmovdqu         " "ymm0, [rdi]"),
+        Q!("    vmovdqu         " "ymm3, [rdi + 0xc8]"),
+        Q!("    vmovdqu         " "ymm1, [rdi + 0x190]"),
+        Q!("    vmovdqu         " "ymm4, [rdi + 0x258]"),
+
+        // Interleave low and high qwords from ymm0(state0[0,1,2,3]) and ymm3(state1[0,1,2,3])
+        Q!("    vpunpcklqdq     " "ymm2, ymm0, ymm3"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm3"),
+
+        // Interleave low and high qwords from ymm1(state2[0,1,2,3]) and ymm4(state3[0,1,2,3])
+        Q!("    vpunpcklqdq     " "ymm3, ymm1, ymm4"),
+
+        // Permute 128-bit lanes to complete the interleave for A[0] and A[2]
+        Q!("    vperm2i128      " "ymm7, ymm2, ymm3, 0x20"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm1, ymm4"),
+        Q!("    vperm2i128      " "ymm3, ymm2, ymm3, 0x31"),
+        Q!("    vmovdqu         " "ymm4, [rdi + 0x278]"),
+        Q!("    vmovdqu         " "[rsp + 0x40], ymm3"),
+
+        // Permute 128-bit lanes to complete the interleave for A[3] and A[1]
+        Q!("    vperm2i128      " "ymm3, ymm0, ymm1, 0x31"),
+        Q!("    vmovdqu         " "[rsp + 0x0], ymm7"),
+        Q!("    vperm2i128      " "ymm7, ymm0, ymm1, 0x20"),
+
+        Q!("    vmovdqu         " "ymm0, [rdi + 0x20]"),
+        Q!("    vmovdqu         " "ymm1, [rdi + 0x1b0]"),
+        Q!("    vmovdqu         " "[rsp + 0x60], ymm3"),
+        Q!("    vmovdqu         " "ymm3, [rdi + 0xe8]"),
+        Q!("    vmovdqu         " "[rsp + 0x20], ymm7"),
+
+        // Load, Interleave, and Store 32 bytes from each of the 4 states (A[4-7])
+        Q!("    vpunpcklqdq     " "ymm2, ymm0, ymm3"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm3"),
+        Q!("    vpunpcklqdq     " "ymm3, ymm1, ymm4"),
+        Q!("    vperm2i128      " "ymm7, ymm2, ymm3, 0x20"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm1, ymm4"),
+        Q!("    vperm2i128      " "ymm3, ymm2, ymm3, 0x31"),
+        Q!("    vmovdqu         " "ymm4, [rdi + 0x298]"),
+        Q!("    vperm2i128      " "ymm14, ymm0, ymm1, 0x31"),
+        Q!("    vmovdqu         " "[rsp + 0x80], ymm7"),
+        Q!("    vperm2i128      " "ymm7, ymm0, ymm1, 0x20"),
+        Q!("    vmovdqu         " "ymm0, [rdi + 0x40]"),
+        Q!("    vmovdqu         " "ymm1, [rdi + 0x1d0]"),
+        Q!("    vmovdqu         " "[rsp + 0xc0], ymm3"),
+        Q!("    vmovdqu         " "ymm3, [rdi + 0x108]"),
+        Q!("    vmovdqu         " "ymm10, ymm14"),
+        Q!("    vmovdqu         " "[rsp + 0xa0], ymm7"),
+
+        // Load, Interleave, and Store 32 bytes from each of the 4 states (A[8-11])
+        Q!("    vpunpcklqdq     " "ymm2, ymm0, ymm3"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm3"),
+        Q!("    vpunpcklqdq     " "ymm3, ymm1, ymm4"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm1, ymm4"),
+        Q!("    vperm2i128      " "ymm11, ymm2, ymm3, 0x20"),
+        Q!("    vperm2i128      " "ymm3, ymm2, ymm3, 0x31"),
+        Q!("    vperm2i128      " "ymm7, ymm0, ymm1, 0x20"),
+        Q!("    vmovdqu         " "[rsp + 0x100], ymm3"),
+        Q!("    vperm2i128      " "ymm8, ymm0, ymm1, 0x31"),
+        Q!("    vmovdqu         " "ymm3, [rdi + 0x128]"),
+        Q!("    vmovdqu         " "ymm0, [rdi + 0x60]"),
+        Q!("    vmovdqu         " "ymm1, [rdi + 0x1f0]"),
+        Q!("    vmovdqu         " "[rsp + 0xe0], ymm7"),
+        Q!("    vmovdqu         " "ymm14, ymm11"),
+        Q!("    vmovdqu         " "ymm4, [rdi + 0x2b8]"),
+        Q!("    vmovdqu         " "ymm5, [rdi + 0x2f8]"),
+
+        // Load, Interleave, and Store 32 bytes from each of the 4 states (A[12-15])
+        Q!("    vpunpcklqdq     " "ymm2, ymm0, ymm3"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm3"),
+        Q!("    vpunpcklqdq     " "ymm3, ymm1, ymm4"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm1, ymm4"),
+        Q!("    vmovdqu         " "ymm4, [rdi + 0x2d8]"),
+        Q!("    vperm2i128      " "ymm15, ymm2, ymm3, 0x20"),
+        Q!("    vperm2i128      " "ymm3, ymm2, ymm3, 0x31"),
+        Q!("    vperm2i128      " "ymm7, ymm0, ymm1, 0x20"),
+        Q!("    vperm2i128      " "ymm9, ymm0, ymm1, 0x31"),
+        Q!("    vmovdqu         " "[rsp + 0x140], ymm3"),
+        Q!("    vmovdqu         " "ymm0, [rdi + 0x80]"),
+        Q!("    vmovdqu         " "ymm3, [rdi + 0x148]"),
+        Q!("    vmovdqu         " "ymm1, [rdi + 0x210]"),
+        Q!("    vmovdqu         " "[rsp + 0x120], ymm7"),
+
+        // Load, Interleave, and Store 32 bytes from each of the 4 states (A[16-19])
+        Q!("    vpunpcklqdq     " "ymm2, ymm0, ymm3"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm3"),
+        Q!("    vpunpcklqdq     " "ymm3, ymm1, ymm4"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm1, ymm4"),
+        Q!("    vperm2i128      " "ymm7, ymm2, ymm3, 0x20"),
+        Q!("    vperm2i128      " "ymm13, ymm2, ymm3, 0x31"),
+        Q!("    vperm2i128      " "ymm3, ymm0, ymm1, 0x31"),
+        Q!("    vmovdqu         " "[rsp + 0x160], ymm7"),
+        Q!("    vperm2i128      " "ymm7, ymm0, ymm1, 0x20"),
+        Q!("    vmovdqu         " "ymm0, [rdi + 0xa0]"),
+        Q!("    vmovdqu         " "ymm1, [rdi + 0x230]"),
+        Q!("    vmovdqu         " "[rsp + 0x1a0], ymm3"),
+        Q!("    vmovdqu         " "ymm3, [rdi + 0x168]"),
+
+        // Load, Interleave, and Store 32 bytes from each of the 4 states (A[20-23])
+        Q!("    vpunpcklqdq     " "ymm4, ymm1, ymm5"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm1, ymm5"),
+        Q!("    vmovdqu         " "[rsp + 0x180], ymm7"),
+        Q!("    vpunpcklqdq     " "ymm2, ymm0, ymm3"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm3"),
+        Q!("    vperm2i128      " "ymm12, ymm2, ymm4, 0x20"),
+        Q!("    vperm2i128      " "ymm3, ymm0, ymm1, 0x20"),
+        Q!("    vperm2i128      " "ymm7, ymm2, ymm4, 0x31"),
+        Q!("    vperm2i128      " "ymm4, ymm0, ymm1, 0x31"),
+
+        // Load, Interleave, and Store 8 bytes from each of the 4 states (A[24])
+        // A[24] is the last element (only 8 bytes per state)
+        Q!("    vmovq           " "xmm0, [rdi + 0x250]"),
+        Q!("    vmovq           " "xmm1, [rdi + 0xc0]"),
+        Q!("    vmovdqu         " "[rsp + 0x1c0], ymm12"),
+        Q!("    vmovdqu         " "[rsp + 0x1e0], ymm4"),
+        Q!("    vpinsrq         " "xmm0, xmm0, [rdi + 0x318], 0x1"),
+        Q!("    vpinsrq         " "xmm1, xmm1, [rdi + 0x188], 0x1"),
+        Q!("    vinserti128     " "ymm2, ymm1, xmm0, 0x1"),
+
+        // Initialize the loop counter
+        Q!("    mov             " "r10, 0"),
+
+        Q!(Label!("Lsha3_keccak4_f1600_alt", 2) ":"),
+
+        // =====================================================================
+        // Theta Step
+        // =====================================================================
+        // Compute the column parities C[x] = A[x,0] xor A[x,1] xor A[x,2] xor A[x,3] xor A[x,4]
+        // Then D[x] = C[x-1] xor ROL(C[x+1], 1)
+        // Then A'[x,y] = A[x,y] xor D[x]
+
+        // Theta step
+        Q!("    vmovdqu         " "ymm4, [rsp + 0xa0]"),
+        Q!("    vpxor           " "ymm0, ymm9, [rsp + 0x1c0]"),
+        Q!("    vmovdqu         " "[rsp + 0x200], ymm9"),
+        Q!("    vmovdqu         " "ymm9, ymm10"),
+        Q!("    vmovdqu         " "ymm11, [rsp + 0xc0]"),
+        Q!("    vmovdqu         " "ymm12, [rsp + 0x160]"),
+        Q!("    vmovdqu         " "[rsp + 0x240], ymm3"),
+        Q!("    vpxor           " "ymm1, ymm4, [rsp + 0x100]"),
+        Q!("    vmovdqu         " "ymm10, [rsp + 0x40]"),
+        Q!("    vmovdqu         " "[rsp + 0x220], ymm4"),
+        Q!("    vpxor           " "ymm12, ymm12, ymm3"),
+        Q!("    vmovdqu         " "ymm6, [rsp + 0x20]"),
+        Q!("    vmovdqu         " "ymm4, [rsp + 0x140]"),
+        Q!("    vmovdqu         " "[rsp + 0x2a0], ymm14"),
+        Q!("    vpxor           " "ymm0, ymm0, ymm1"),
+        Q!("    vpxor           " "ymm1, ymm11, ymm8"),
+        Q!("    vpxor           " "ymm11, ymm7, [rsp + 0x180]"),
+        Q!("    vmovdqu         " "[rsp + 0x280], ymm10"),
+        Q!("    vpxor           " "ymm12, ymm12, ymm1"),
+        Q!("    vpxor           " "ymm1, ymm9, ymm15"),
+        Q!("    vmovdqu         " "ymm3, [rsp + 0xe0]"),
+        Q!("    vmovdqu         " "[rsp + 0x260], ymm8"),
+        Q!("    vpxor           " "ymm11, ymm11, ymm1"),
+        Q!("    vpxor           " "ymm1, ymm14, [rsp + 0x120]"),
+        Q!("    vpxor           " "ymm12, ymm12, ymm6"),
+        Q!("    vmovdqu         " "ymm8, [rsp + 0x60]"),
+        Q!("    vpxor           " "ymm11, ymm11, ymm10"),
+        Q!("    vpxor           " "ymm10, ymm13, [rsp + 0x1e0]"),
+        Q!("    vpxor           " "ymm3, ymm3, ymm4"),
+        Q!("    vmovdqu         " "[rsp + 0x2c0], ymm4"),
+        Q!("    vpsrlq          " "ymm4, ymm12, 0x3f"),
+        Q!("    vpsrlq          " "ymm5, ymm11, 0x3f"),
+        Q!("    vpxor           " "ymm0, ymm0, [rsp + 0x0]"),
+        Q!("    vpxor           " "ymm10, ymm10, ymm1"),
+        Q!("    vmovdqu         " "ymm1, [rsp + 0x80]"),
+        Q!("    vpxor           " "ymm10, ymm10, ymm8"),
+        Q!("    vmovdqu         " "ymm14, ymm1"),
+        Q!("    vpxor           " "ymm1, ymm2, [rsp + 0x1a0]"),
+        Q!("    vmovdqu         " "[rsp + 0x2e0], ymm14"),
+        Q!("    vpxor           " "ymm1, ymm1, ymm3"),
+        Q!("    vpsllq          " "ymm3, ymm12, 0x1"),
+        Q!("    vpor            " "ymm3, ymm3, ymm4"),
+        Q!("    vpsllq          " "ymm4, ymm11, 0x1"),
+        Q!("    vpxor           " "ymm1, ymm1, ymm14"),
+
+        // C[0] = ymm0
+        // C[1] = ymm12
+        // C[2] = ymm11
+        // C[3] = ymm10
+        // C[4] = ymm1
+
+        Q!("    vpor            " "ymm4, ymm4, ymm5"),
+        Q!("    vpsrlq          " "ymm14, ymm10, 0x3f"),
+        Q!("    vpxor           " "ymm3, ymm3, ymm1"),
+        Q!("    vpsllq          " "ymm5, ymm10, 0x1"),
+        Q!("    vpxor           " "ymm4, ymm4, ymm0"),
+        Q!("    vpor            " "ymm5, ymm5, ymm14"),
+        Q!("    vpxor           " "ymm6, ymm4, ymm6"),
+        Q!("    vpxor           " "ymm5, ymm5, ymm12"),
+        Q!("    vpsrlq          " "ymm12, ymm1, 0x3f"),
+        Q!("    vpsllq          " "ymm1, ymm1, 0x1"),
+        Q!("    vpxor           " "ymm7, ymm5, ymm7"),
+        Q!("    vpxor           " "ymm9, ymm5, ymm9"),
+        Q!("    vpor            " "ymm1, ymm1, ymm12"),
+        Q!("    vpxor           " "ymm12, ymm3, [rsp + 0x0]"),
+        Q!("    vpxor           " "ymm1, ymm1, ymm11"),
+        Q!("    vpsrlq          " "ymm11, ymm0, 0x3f"),
+        Q!("    vpsllq          " "ymm0, ymm0, 0x1"),
+        Q!("    vpxor           " "ymm13, ymm1, ymm13"),
+        Q!("    vpxor           " "ymm8, ymm1, ymm8"),
+        Q!("    vpor            " "ymm0, ymm0, ymm11"),
+        Q!("    vpxor           " "ymm0, ymm0, ymm10"),
+
+        // D[0] = ymm3
+        // D[1] = ymm4
+        // D[2] = ymm5
+        // D[3] = ymm1
+        // D[4] = ymm0
+
+        Q!("    vpxor           " "ymm10, ymm4, [rsp + 0xc0]"),
+        Q!("    vpxor           " "ymm2, ymm0, ymm2"),
+
+        // Rho, Pi, and Chi Steps (interleaved for performance)
+        // B[x,y] = ROL(A'[...], rotation_constant) placed at position determined by Pi
+        // A''[x,y] = B[x,y] XOR ((NOT B[x+1,y]) AND B[x+2,y])
+
+        Q!("    vpsrlq          " "ymm11, ymm10, 0x14"),
+        Q!("    vpsllq          " "ymm10, ymm10, 0x2c"),
+        Q!("    vpor            " "ymm10, ymm10, ymm11"),
+
+        Q!("    vpxor           " "ymm11, ymm5, ymm15"),
+        Q!("    vpbroadcastq    " "ymm15, [rsi]"),
+        Q!("    vpsrlq          " "ymm14, ymm11, 0x15"),
+        Q!("    vpsllq          " "ymm11, ymm11, 0x2b"),
+        Q!("    vpor            " "ymm11, ymm11, ymm14"),
+
+        Q!("    vpandn          " "ymm14, ymm10, ymm11"),
+        Q!("    vpxor           " "ymm14, ymm14, ymm15"),
+        Q!("    vpxor           " "ymm15, ymm14, ymm12"),
+
+        Q!("    vpsrlq          " "ymm14, ymm13, 0x2b"),
+        Q!("    vpsllq          " "ymm13, ymm13, 0x15"),
+        Q!("    vmovdqu         " "[rsp + 0x0], ymm15"),
+        Q!("    vpor            " "ymm13, ymm13, ymm14"),
+
+        Q!("    vpandn          " "ymm14, ymm11, ymm13"),
+        Q!("    vpxor           " "ymm15, ymm14, ymm10"),
+
+        Q!("    vpsrlq          " "ymm14, ymm2, 0x32"),
+        Q!("    vpsllq          " "ymm2, ymm2, 0xe"),
+        Q!("    vmovdqu         " "[rsp + 0x20], ymm15"),
+        Q!("    vpor            " "ymm2, ymm2, ymm14"),
+
+        // **** B[0]-B[4] Register Allocation Map ****
+        // B[0]  (B[0,0])    ymm12   (A'[0,0] (A'[0]) unchanged, no rotation)
+        // B[1]  (B[1,0])    ymm10   ROL(A'[1,1] (A'[6]),  44)
+        // B[2]  (B[2,0])    ymm11   ROL(A'[2,2] (A'[12]), 43)
+        // B[3]  (B[3,0])    ymm13   ROL(A'[3,3] (A'[18]), 21)
+        // B[4]  (B[4,0])    ymm2    ROL(A'[4,4] (A'[24]), 14)
+
+        Q!("    vpandn          " "ymm14, ymm13, ymm2"),
+        Q!("    vpxor           " "ymm11, ymm14, ymm11"),
+        Q!("    vmovdqu         " "[rsp + 0x40], ymm11"),
+        Q!("    vpandn          " "ymm11, ymm2, ymm12"),
+        Q!("    vpandn          " "ymm12, ymm12, ymm10"),
+        Q!("    vpxor           " "ymm11, ymm11, ymm13"),
+        Q!("    vmovdqu         " "[rsp + 0x60], ymm11"),
+        Q!("    vpxor           " "ymm11, ymm12, ymm2"),
+
+        Q!("    vpsrlq          " "ymm2, ymm8, 0x24"),
+        Q!("    vpsllq          " "ymm8, ymm8, 0x1c"),
+        Q!("    vmovdqu         " "[rsp + 0x80], ymm11"),
+        Q!("    vpor            " "ymm8, ymm8, ymm2"),
+
+        Q!("    vpxor           " "ymm2, ymm0, [rsp + 0xe0]"),
+        Q!("    vpsrlq          " "ymm10, ymm2, 0x2c"),
+        Q!("    vpsllq          " "ymm2, ymm2, 0x14"),
+        Q!("    vpor            " "ymm2, ymm2, ymm10"),
+
+        Q!("    vpxor           " "ymm10, ymm3, [rsp + 0x100]"),
+        Q!("    vpsrlq          " "ymm11, ymm10, 0x3d"),
+        Q!("    vpsllq          " "ymm10, ymm10, 0x3"),
+        Q!("    vpor            " "ymm10, ymm10, ymm11"),
+
+        Q!("    vpandn          " "ymm11, ymm2, ymm10"),
+        Q!("    vpxor           " "ymm11, ymm11, ymm8"),
+        Q!("    vmovdqu         " "[rsp + 0xa0], ymm11"),
+
+        Q!("    vpxor           " "ymm11, ymm4, [rsp + 0x160]"),
+        Q!("    vpsrlq          " "ymm12, ymm11, 0x13"),
+        Q!("    vpsllq          " "ymm11, ymm11, 0x2d"),
+        Q!("    vpor            " "ymm11, ymm11, ymm12"),
+
+        Q!("    vpandn          " "ymm12, ymm10, ymm11"),
+        Q!("    vpxor           " "ymm12, ymm12, ymm2"),
+        Q!("    vmovdqu         " "[rsp + 0xc0], ymm12"),
+
+        Q!("    vpsrlq          " "ymm12, ymm7, 0x3"),
+        Q!("    vpsllq          " "ymm7, ymm7, 0x3d"),
+        Q!("    vpor            " "ymm7, ymm7, ymm12"),
+
+        // **** B[5]-B[9] Register Allocation Map ****
+        // B[5]  (B[0,1])    ymm8    ROL(A'[3,0] (A'[3]), 28)
+        // B[6]  (B[1,1])    ymm2    ROL(A'[4,1] (A'[9]), 20)
+        // B[7]  (B[2,1])    ymm10   ROL(A'[0,2] (A'[10]), 3)
+        // B[8]  (B[3,1])    ymm11   ROL(A'[1,3] (A'[16]), 45)
+        // B[9]  (B[4,1])    ymm7    ROL(A'[2,4] (A'[22]), 61)
+
+        Q!("    vpandn          " "ymm12, ymm11, ymm7"),
+        Q!("    vpxor           " "ymm10, ymm12, ymm10"),
+
+        Q!("    vpandn          " "ymm12, ymm7, ymm8"),
+        Q!("    vpandn          " "ymm8, ymm8, ymm2"),
+
+        Q!("    vpsrlq          " "ymm2, ymm6, 0x3f"),
+        Q!("    vpsllq          " "ymm6, ymm6, 0x1"),
+        Q!("    vpxor           " "ymm14, ymm12, ymm11"),
+        Q!("    vpor            " "ymm6, ymm6, ymm2"),
+
+        Q!("    vpsrlq          " "ymm2, ymm9, 0x3a"),
+        Q!("    vpxor           " "ymm12, ymm8, ymm7"),
+        Q!("    vpsllq          " "ymm9, ymm9, 0x6"),
+        Q!("    vmovdqu         " "[rsp + 0xe0], ymm12"),
+
+        Q!("    vpxor           " "ymm7, ymm0, [rsp + 0x1a0]"),
+        Q!("    vpor            " "ymm9, ymm9, ymm2"),
+
+        Q!("    vpxor           " "ymm2, ymm1, [rsp + 0x120]"),
+        Q!("    vpshufb         " "ymm7, ymm7, [rdx]"),
+        Q!("    vpsrlq          " "ymm11, ymm2, 0x27"),
+        Q!("    vpsllq          " "ymm2, ymm2, 0x19"),
+        Q!("    vpor            " "ymm11, ymm11, ymm2"),
+
+        Q!("    vpandn          " "ymm2, ymm9, ymm11"),
+        Q!("    vpandn          " "ymm8, ymm11, ymm7"),
+        Q!("    vpxor           " "ymm12, ymm2, ymm6"),
+
+        Q!("    vpxor           " "ymm2, ymm3, [rsp + 0x1c0]"),
+        Q!("    vpxor           " "ymm8, ymm8, ymm9"),
+        Q!("    vmovdqu         " "[rsp + 0x100], ymm12"),
+        Q!("    vpsrlq          " "ymm12, ymm2, 0x2e"),
+        Q!("    vpsllq          " "ymm2, ymm2, 0x12"),
+        Q!("    vpor            " "ymm2, ymm12, ymm2"),
+
+        // **** B[10]-B[14] Register Allocation Map ****
+        // B[10] (B[0,2])    ymm6    ROL(A'[1,0] (A'[1]), 1)
+        // B[11] (B[1,2])    ymm9    ROL(A'[2,1] (A'[7]), 6)
+        // B[12] (B[2,2])    ymm11   ROL(A'[3,2] (A'[13]), 25)
+        // B[13] (B[3,2])    ymm7    ROL(A'[4,3] (A'[19]), 8)
+        // B[14] (B[4,2])    ymm2    ROL(A'[0,4] (A'[20]), 18)
+
+        Q!("    vpandn          " "ymm12, ymm7, ymm2"),
+        Q!("    vpxor           " "ymm15, ymm12, ymm11"),
+
+        Q!("    vpandn          " "ymm11, ymm2, ymm6"),
+        Q!("    vpandn          " "ymm6, ymm6, ymm9"),
+        Q!("    vpxor           " "ymm12, ymm11, ymm7"),
+        Q!("    vmovdqu         " "[rsp + 0x120], ymm12"),
+
+        Q!("    vpxor           " "ymm12, ymm6, ymm2"),
+
+        Q!("    vpxor           " "ymm6, ymm0, [rsp + 0x2e0]"),
+        Q!("    vpxor           " "ymm0, ymm0, [rsp + 0x2c0]"),
+        Q!("    vmovdqu         " "[rsp + 0x140], ymm12"),
+        Q!("    vpsrlq          " "ymm2, ymm6, 0x25"),
+        Q!("    vpsllq          " "ymm6, ymm6, 0x1b"),
+        Q!("    vpor            " "ymm2, ymm2, ymm6"),
+
+        Q!("    vpxor           " "ymm6, ymm3, [rsp + 0x220]"),
+        Q!("    vpxor           " "ymm3, ymm3, [rsp + 0x200]"),
+        Q!("    vpsrlq          " "ymm7, ymm6, 0x1c"),
+        Q!("    vpsllq          " "ymm6, ymm6, 0x24"),
+        Q!("    vpor            " "ymm7, ymm7, ymm6"),
+
+        Q!("    vpxor           " "ymm6, ymm4, [rsp + 0x260]"),
+        Q!("    vpxor           " "ymm4, ymm4, [rsp + 0x240]"),
+        Q!("    vpsrlq          " "ymm12, ymm6, 0x36"),
+        Q!("    vpsllq          " "ymm6, ymm6, 0xa"),
+        Q!("    vpor            " "ymm12, ymm12, ymm6"),
+
+        Q!("    vpxor           " "ymm6, ymm5, [rsp + 0x180]"),
+        Q!("    vpxor           " "ymm5, ymm5, [rsp + 0x280]"),
+
+        Q!("    vpandn          " "ymm9, ymm7, ymm12"),
+        Q!("    vpsrlq          " "ymm11, ymm6, 0x31"),
+        Q!("    vpsllq          " "ymm6, ymm6, 0xf"),
+        Q!("    vpxor           " "ymm9, ymm9, ymm2"),
+        Q!("    vpor            " "ymm11, ymm11, ymm6"),
+
+        Q!("    vpandn          " "ymm6, ymm12, ymm11"),
+        Q!("    vpxor           " "ymm6, ymm6, ymm7"),
+        Q!("    vmovdqu         " "[rsp + 0x160], ymm6"),
+
+        Q!("    vpxor           " "ymm6, ymm1, [rsp + 0x1e0]"),
+        Q!("    vpxor           " "ymm1, ymm1, [rsp + 0x2a0]"),
+        Q!("    vpshufb         " "ymm6, ymm6, [rcx]"),
+
+        // **** B[15]-B[19] Register Allocation Map ****
+        // B[15] (B[0,3])    ymm2    ROL(A'[4,0] (A'[4]), 27)
+        // B[16] (B[1,3])    ymm7    ROL(A'[0,1] (A'[5]), 36)
+        // B[17] (B[2,3])    ymm12   ROL(A'[1,2] (A'[11]), 10)
+        // B[18] (B[3,3])    ymm11   ROL(A'[2,3] (A'[17]), 15)
+        // B[19] (B[4,3])    ymm6    ROL(A'[3,4] (A'[23]), 56)
+
+        Q!("    vpandn          " "ymm13, ymm11, ymm6"),
+        Q!("    vpxor           " "ymm13, ymm13, ymm12"),
+        Q!("    vmovdqu         " "[rsp + 0x180], ymm13"),
+
+        Q!("    vpandn          " "ymm13, ymm6, ymm2"),
+        Q!("    vpandn          " "ymm2, ymm2, ymm7"),
+        Q!("    vpxor           " "ymm2, ymm2, ymm6"),
+
+        Q!("    vpsrlq          " "ymm6, ymm4, 0x3e"),
+        Q!("    vpxor           " "ymm13, ymm13, ymm11"),
+        Q!("    vmovdqu         " "[rsp + 0x1a0], ymm2"),
+        Q!("    vpsrlq          " "ymm2, ymm5, 0x2"),
+        Q!("    vpsllq          " "ymm5, ymm5, 0x3e"),
+        Q!("    vpor            " "ymm2, ymm2, ymm5"),
+
+        Q!("    vpsrlq          " "ymm5, ymm1, 0x9"),
+        Q!("    vpsllq          " "ymm1, ymm1, 0x37"),
+
+        Q!("    vpsllq          " "ymm4, ymm4, 0x2"),
+        Q!("    vpor            " "ymm1, ymm5, ymm1"),
+
+        Q!("    vpsrlq          " "ymm5, ymm0, 0x19"),
+        Q!("    vpor            " "ymm4, ymm6, ymm4"),
+        Q!("    vpsllq          " "ymm0, ymm0, 0x27"),
+        Q!("    vpor            " "ymm5, ymm5, ymm0"),
+
+        Q!("    vpandn          " "ymm0, ymm1, ymm5"),
+        Q!("    vpxor           " "ymm0, ymm0, ymm2"),
+        Q!("    vmovdqu         " "[rsp + 0x1c0], ymm0"),
+
+        Q!("    vpsrlq          " "ymm0, ymm3, 0x17"),
+        Q!("    vpsllq          " "ymm3, ymm3, 0x29"),
+        Q!("    vpor            " "ymm0, ymm0, ymm3"),
+
+        // **** B[20]-B[24] Register Allocation Map ****
+        // B[20] (B[0,4])    ymm2    ROL(A'[2,0] (A'[2]), 62)
+        // B[21] (B[1,4])    ymm1    ROL(A'[3,1] (A'[8]), 55)
+        // B[22] (B[2,4])    ymm5    ROL(A'[4,2] (A'[14]), 39)
+        // B[23] (B[3,4])    ymm4    ROL(A'[1,4] (A'[21]), 2)
+        // B[24] (B[4,4])    ymm0    ROL(A'[0,3] (A'[15]), 41)
+
+        Q!("    vpandn          " "ymm7, ymm0, ymm4"),
+        Q!("    vpandn          " "ymm3, ymm5, ymm0"),
+        Q!("    vpxor           " "ymm7, ymm7, ymm5"),
+
+        Q!("    vpandn          " "ymm5, ymm4, ymm2"),
+        Q!("    vpandn          " "ymm2, ymm2, ymm1"),
+        Q!("    vpxor           " "ymm5, ymm5, ymm0"),
+
+        Q!("    vpxor           " "ymm3, ymm3, ymm1"),
+
+        Q!("    vpxor           " "ymm2, ymm2, ymm4"),
+        Q!("    vmovdqu         " "[rsp + 0x1e0], ymm5"),
+
+        Q!("    add             " "rsi, 8"),
+        Q!("    add             " "r10, 1"),
+        Q!("    cmp             " "r10, 0x18"),
+        Q!("    jne             " Label!("Lsha3_keccak4_f1600_alt", 2, Before)),
+
+        // Load, De-interleave, and Store 32 bytes to each of the 4 states (A[0-3])
+        Q!("    vmovdqu         " "ymm4, [rsp + 0x0]"),
+        Q!("    vmovdqu         " "ymm5, [rsp + 0x40]"),
+        Q!("    vmovdqu         " "ymm0, [rsp + 0x20]"),
+        Q!("    vmovdqu         " "ymm1, [rsp + 0x60]"),
+        Q!("    vmovdqu         " "ymm12, [rsp + 0x1c0]"),
+        Q!("    vmovdqu         " "[rsp + 0x1c0], ymm2"),
+
+        // De-interleave ymm4(A[0]) and ymm0(A[1])
+        Q!("    vpunpcklqdq     " "ymm2, ymm4, ymm0"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm4, ymm0"),
+        // De-interleave ymm5(A[2]) and ymm1(A[3])
+        Q!("    vpunpcklqdq     " "ymm4, ymm5, ymm1"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm5, ymm1"),
+
+        // Permute 128-bit lanes to complete the de-interleave
+        Q!("    vperm2i128      " "ymm6, ymm2, ymm4, 0x20"),
+        Q!("    vperm2i128      " "ymm2, ymm2, ymm4, 0x31"),
+        Q!("    vmovdqu         " "ymm4, [rsp + 0x80]"),
+        Q!("    vperm2i128      " "ymm5, ymm0, ymm1, 0x20"),
+        Q!("    vperm2i128      " "ymm0, ymm0, ymm1, 0x31"),
+
+        // Store de-interleaved results back to output
+        Q!("    vmovdqu         " "[rdi], ymm6"),
+        Q!("    vmovdqu         " "[rdi + 0xc8], ymm5"),
+        Q!("    vmovdqu         " "[rdi + 0x190], ymm2"),
+        Q!("    vmovdqu         " "[rdi + 0x258], ymm0"),
+
+        // Load, De-interleave, and Store 32 bytes to each of the 4 states (A[4-7])
+        Q!("    vmovdqu         " "ymm0, [rsp + 0xa0]"),
+        Q!("    vpunpcklqdq     " "ymm2, ymm4, ymm0"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm4, ymm0"),
+        Q!("    vmovdqu         " "ymm0, [rsp + 0xc0]"),
+        Q!("    vpunpcklqdq     " "ymm4, ymm0, ymm10"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm10"),
+        Q!("    vperm2i128      " "ymm6, ymm2, ymm4, 0x20"),
+        Q!("    vperm2i128      " "ymm5, ymm1, ymm0, 0x20"),
+        Q!("    vperm2i128      " "ymm2, ymm2, ymm4, 0x31"),
+        Q!("    vmovdqu         " "ymm4, [rsp + 0xe0]"),
+        Q!("    vperm2i128      " "ymm1, ymm1, ymm0, 0x31"),
+        Q!("    vmovdqu         " "ymm0, [rsp + 0x100]"),
+        Q!("    vmovdqu         " "[rdi + 0x1b0], ymm2"),
+        Q!("    vmovdqu         " "[rdi + 0x278], ymm1"),
+
+        // Load, De-interleave, and Store 32 bytes to each of the 4 states (A[8-11])
+        Q!("    vpunpcklqdq     " "ymm2, ymm14, ymm4"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm14, ymm4"),
+        Q!("    vpunpcklqdq     " "ymm4, ymm0, ymm8"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm8"),
+        Q!("    vmovdqu         " "[rdi + 0x20], ymm6"),
+        Q!("    vmovdqu         " "[rdi + 0xe8], ymm5"),
+        Q!("    vperm2i128      " "ymm6, ymm2, ymm4, 0x20"),
+        Q!("    vperm2i128      " "ymm5, ymm1, ymm0, 0x20"),
+        Q!("    vperm2i128      " "ymm2, ymm2, ymm4, 0x31"),
+        Q!("    vperm2i128      " "ymm1, ymm1, ymm0, 0x31"),
+        Q!("    vmovdqu         " "ymm4, [rsp + 0x120]"),
+        Q!("    vmovdqu         " "ymm0, [rsp + 0x140]"),
+        Q!("    vmovdqu         " "[rdi + 0x1d0], ymm2"),
+        Q!("    vmovdqu         " "[rdi + 0x298], ymm1"),
+
+        // Load, De-interleave, and Store 32 bytes to each of the 4 states (A[12-15])
+        Q!("    vpunpcklqdq     " "ymm2, ymm15, ymm4"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm15, ymm4"),
+        Q!("    vpunpcklqdq     " "ymm4, ymm0, ymm9"),
+        Q!("    vmovdqu         " "[rdi + 0x108], ymm5"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm0, ymm9"),
+        Q!("    vmovdqu         " "[rdi + 0x40], ymm6"),
+        Q!("    vperm2i128      " "ymm6, ymm2, ymm4, 0x20"),
+        Q!("    vperm2i128      " "ymm2, ymm2, ymm4, 0x31"),
+        Q!("    vperm2i128      " "ymm5, ymm1, ymm0, 0x20"),
+        Q!("    vmovdqu         " "ymm4, [rsp + 0x160]"),
+        Q!("    vperm2i128      " "ymm1, ymm1, ymm0, 0x31"),
+        Q!("    vmovdqu         " "ymm0, [rsp + 0x180]"),
+        Q!("    vmovdqu         " "[rdi + 0x128], ymm5"),
+        Q!("    vmovdqu         " "ymm5, [rsp + 0x1a0]"),
+        Q!("    vmovdqu         " "[rdi + 0x1f0], ymm2"),
+
+        // Load, De-interleave, and Store 32 bytes to each of the 4 states (A[16-19])
+        Q!("    vpunpcklqdq     " "ymm2, ymm4, ymm0"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm4, ymm0"),
+        Q!("    vpunpcklqdq     " "ymm4, ymm13, ymm5"),
+        Q!("    vmovdqu         " "[rdi + 0x60], ymm6"),
+        Q!("    vperm2i128      " "ymm6, ymm2, ymm4, 0x20"),
+        Q!("    vmovdqu         " "[rdi + 0x2b8], ymm1"),
+        Q!("    vperm2i128      " "ymm2, ymm2, ymm4, 0x31"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm13, ymm5"),
+        Q!("    vmovdqu         " "[rdi + 0x80], ymm6"),
+        Q!("    vmovdqu         " "ymm4, [rsp + 0x1e0]"),
+        Q!("    vperm2i128      " "ymm5, ymm0, ymm1, 0x20"),
+        Q!("    vperm2i128      " "ymm0, ymm0, ymm1, 0x31"),
+        Q!("    vmovdqu         " "[rdi + 0x210], ymm2"),
+
+        // Load, De-interleave, and Store 32 bytes to each of the 4 states (A[20-23])
+        Q!("    vpunpcklqdq     " "ymm2, ymm12, ymm3"),
+        Q!("    vmovdqu         " "[rdi + 0x2d8], ymm0"),
+        Q!("    vpunpckhqdq     " "ymm0, ymm12, ymm3"),
+        Q!("    vpunpcklqdq     " "ymm3, ymm7, ymm4"),
+        Q!("    vpunpckhqdq     " "ymm1, ymm7, ymm4"),
+        Q!("    vmovdqu         " "[rdi + 0x148], ymm5"),
+        Q!("    vperm2i128      " "ymm5, ymm2, ymm3, 0x20"),
+        Q!("    vperm2i128      " "ymm2, ymm2, ymm3, 0x31"),
+        Q!("    vmovdqu         " "ymm3, [rsp + 0x1c0]"),
+        Q!("    vperm2i128      " "ymm4, ymm0, ymm1, 0x20"),
+        Q!("    vperm2i128      " "ymm0, ymm0, ymm1, 0x31"),
+
+        // Store de-interleaved results back to output
+        Q!("    vmovdqu         " "[rdi + 0xa0], ymm5"),
+        Q!("    vextracti128    " "xmm15, ymm3, 0x1"),
+        Q!("    vmovdqu         " "[rdi + 0x168], ymm4"),
+        Q!("    vmovdqu         " "[rdi + 0x230], ymm2"),
+        Q!("    vmovdqu         " "[rdi + 0x2f8], ymm0"),
+
+        // Load, De-interleave, and Store 8 bytes to each of the 4 states (A[24])
+        // A[24] is the last element (only 8 bytes per state)
+        Q!("    vmovq           " "[rdi + 0xc0], xmm3"),
+        Q!("    vmovhpd         " "[rdi + 0x188], xmm3"),
+        Q!("    vmovq           " "[rdi + 0x250], xmm15"),
+        Q!("    vmovhpd         " "[rdi + 0x318], xmm15"),
+        Q!("    mov             " "rsp, r11"),
+
+        inout("rdi") a.as_mut_ptr() => _,
+        inout("rsi") rc.as_ptr() => _,
+        inout("rdx") rho8.as_ptr() => _,
+        inout("rcx") rho56.as_ptr() => _,
+        // clobbers
+        out("r10") _,
+        out("r11") _,
+        out("zmm0") _,
+        out("zmm1") _,
+        out("zmm10") _,
+        out("zmm11") _,
+        out("zmm12") _,
+        out("zmm13") _,
+        out("zmm14") _,
+        out("zmm15") _,
+        out("zmm2") _,
+        out("zmm3") _,
+        out("zmm4") _,
+        out("zmm5") _,
+        out("zmm6") _,
+        out("zmm7") _,
+        out("zmm8") _,
+        out("zmm9") _,
+            )
+    };
+}

--- a/graviola/src/low/x86_64/sha3_keccak4_f1600_shim.rs
+++ b/graviola/src/low/x86_64/sha3_keccak4_f1600_shim.rs
@@ -1,0 +1,20 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+#[inline]
+pub(crate) fn sha3_keccak4_f1600(a: &mut [[u64; 25]; 4], rc: &[u64; 24]) {
+    super::sha3_keccak4_f1600_alt::sha3_keccak4_f1600(a, rc, &RHO8, &RHO56);
+}
+
+static RHO8: [u64; 4] = [
+    0x0605040302010007,
+    0x0E0D0C0B0A09080F,
+    0x1615141312111017,
+    0x1E1D1C1B1A19181F,
+];
+static RHO56: [u64; 4] = [
+    0x0007060504030201,
+    0x080F0E0D0C0B0A09,
+    0x1017161514131211,
+    0x181F1E1D1C1B1A19,
+];

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -148,15 +148,13 @@ impl DecapKey {
         let g = g.finish();
         let (rho, sigma) = g.split_at(32);
         let rho: [u8; 32] = rho.try_into().unwrap();
+        let sigma = sigma.try_into().unwrap();
 
         // 3. - 7.
         let a_hat = Coeffs::sample_poly(&rho);
 
-        // 8. - 11.
-        let s = Coeffs::sample_poly_cbd(sigma, 0..K_BYTE);
-
-        // 12. - 15.
-        let e = Coeffs::sample_poly_cbd(sigma, K_BYTE..K_BYTE * 2);
+        // 8. - 15.
+        let (s, e) = Coeffs::sample_poly_cbd_dual(sigma);
 
         // 16. ŝ <- NTT(s)
         let mut s_hat = s.ntt();
@@ -292,10 +290,8 @@ impl EncapKey {
         // 4. - 8. rolled into self.transpose_a_hat.
 
         // 9. - 12.
-        let y = Coeffs::sample_poly_cbd(&r.0, 0..K_BYTE);
-
         // 13. - 16.
-        let e_1 = Coeffs::sample_poly_cbd(&r.0, K_BYTE..K_BYTE * 2);
+        let (y, e_1) = Coeffs::sample_poly_cbd_dual(&r.0);
 
         // 17. e_2 <- SamplePolyCBD(PRF (r, N))
         let mut buf = [0u8; 128];
@@ -742,12 +738,22 @@ fn compress_1_x8(coeffs: &[i16; 8]) -> u8 {
 }
 
 impl Coeffs<{ K * N }, Normal> {
-    fn sample_poly_cbd(sigma: &[u8], ns: Range<u8>) -> Self {
+    /// This is dual, K-wise `SamplePolyCBD`.
+    ///
+    /// In other words, it produces two noise vectors.
+    fn sample_poly_cbd_dual(sigma: &[u8; 32]) -> (Self, Self) {
+        (
+            Self::sample_poly_cbd(sigma, 0..K_BYTE),
+            Self::sample_poly_cbd(sigma, K_BYTE..K_BYTE * 2),
+        )
+    }
+
+    fn sample_poly_cbd(sigma: &[u8; 32], ns: Range<u8>) -> Self {
         let mut r = Coeffs::zero();
         let (rows, _) = r.0.as_chunks_mut();
+        let mut buf = [0u8; 128];
 
         for (i, n) in ns.enumerate() {
-            let mut buf = [0u8; 128];
             sha3::Shake256::new(&[sigma, &[n]]).read(&mut buf);
             sample_cbd2(&buf, &mut rows[i]);
         }

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -191,7 +191,7 @@ impl DecapKey {
         let v_prime = Coeffs::decompress_from_bytes_dv_4(c_2.try_into().unwrap());
 
         // 5. s^ <- ByteDecode_12(dk_PKE)
-        let s_hat = Coeffs::from_bytes(self.dk_pke);
+        let s_hat = Coeffs::from_bytes(&self.dk_pke);
 
         // 6. w <- v' - NTT-1(transpose(s^) * NTT(u'))
         let w = v_prime.sub(&s_hat.mul_and_inverse_ntt(&u_prime.ntt()));
@@ -229,7 +229,7 @@ impl EncapKey {
         //   test <- ByteEncode_12(ByteDecode_12(ek[0 ∶ 384k]))
         //
         // If test != ek[0 ∶ 384k], then input checking failed.
-        if t_hat != Coeffs::from_bytes(t_hat).to_bytes() {
+        if t_hat != Coeffs::from_bytes(&t_hat).to_bytes() {
             return Err(Error::OutOfRange);
         }
 
@@ -285,7 +285,7 @@ impl EncapKey {
 
     fn kpke_encrypt(&self, m: Message, r: KpkeRandomness) -> Ciphertext {
         // 2. t^ <- ByteDecode12(ekPKE[0 ∶ 384k])
-        let t_hat = Coeffs::from_bytes(self.t_hat);
+        let t_hat = Coeffs::from_bytes(&self.t_hat);
 
         // 3. 𝜌 <- ekPKE[384k ∶ 384k + 32]
         //  - only required for a_hat expansion
@@ -615,7 +615,7 @@ const SAMPLE_POLY_WORK: &[(u8, u8, usize)] = &[
 
 impl Coeffs<{ K * N }, Ntt> {
     /// This is `ByteDecode_12(bytes)`.
-    fn from_bytes(bytes: [u8; 1152]) -> Self {
+    fn from_bytes(bytes: &[u8; 1152]) -> Self {
         let mut r = Coeffs::zero();
 
         let (r_chunks, _) = r.0.as_chunks_mut();

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -467,9 +467,29 @@ impl Coeffs<{ K * K * N }, Ntt> {
 
         r
     }
+
     fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; 256 * 4]) {
-        for (input, output) in inputs.iter().zip(outputs.chunks_exact_mut(N)) {
-            Shake128ForMlKem::new(&[rho, *input]).sample_into(output.try_into().unwrap());
+        let buf0 = prepare(rho, inputs[0]);
+        let buf1 = prepare(rho, inputs[1]);
+        let buf2 = prepare(rho, inputs[2]);
+        let buf3 = prepare(rho, inputs[3]);
+
+        let [q0, q1, q2, q3] = sha3::SqueezingSponge::shake128_new4(&[&buf0, &buf1, &buf2, &buf3]);
+        let [o0, o1, o2, o3] = outputs.as_chunks_mut().0 else {
+            unreachable!()
+        };
+
+        Shake128ForMlKem { sponge: q0 }.sample_into(o0);
+        Shake128ForMlKem { sponge: q1 }.sample_into(o1);
+        Shake128ForMlKem { sponge: q2 }.sample_into(o2);
+        Shake128ForMlKem { sponge: q3 }.sample_into(o3);
+
+        fn prepare(rho: &[u8; 32], inp: &[u8; 2]) -> [u8; 40] {
+            let mut buf = [0; 40];
+            buf[..32].copy_from_slice(rho);
+            buf[32..34].copy_from_slice(inp);
+            buf[34] = sha3::SHAKE_PAD_BYTE;
+            buf
         }
     }
 

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -425,19 +425,52 @@ impl Coeffs<{ K * K * N }, Ntt> {
     fn _sample_poly_ntt<const TRANSPOSED: bool>(rho: &[u8; 32]) -> Self {
         let mut r = Coeffs::zero();
 
-        for (i, matrix_row) in r.0.chunks_exact_mut(K * N).enumerate() {
-            for (j, poly) in matrix_row.chunks_exact_mut(N).enumerate() {
-                let input = match TRANSPOSED {
-                    false => &[j as u8, i as u8],
-                    true => &[i as u8, j as u8],
-                };
-                Shake128ForMlKem::new(&[rho, input]).sample_into(poly.try_into().unwrap());
-            }
+        // We have K * K polynomials to generate.  In this case, K := 3, so 9.
+        // We have a by-4 keccak, so we can attack the problem in two
+        // sets of four, followed by one straggler.
+
+        let mut work_iter = SAMPLE_POLY_WORK.chunks_exact(4);
+
+        for c4 in work_iter.by_ref() {
+            let inputs = match TRANSPOSED {
+                false => &[
+                    &[c4[0].1, c4[0].0],
+                    &[c4[1].1, c4[1].0],
+                    &[c4[2].1, c4[2].0],
+                    &[c4[3].1, c4[3].0],
+                ],
+                true => &[
+                    &[c4[0].0, c4[0].1],
+                    &[c4[1].0, c4[1].1],
+                    &[c4[2].0, c4[2].1],
+                    &[c4[3].0, c4[3].1],
+                ],
+            };
+
+            Self::_sample_poly_ntt_quad(
+                rho,
+                inputs,
+                (&mut r.0[c4[0].2..c4[3].2 + N]).try_into().unwrap(),
+            );
+        }
+
+        for (i, j, offs) in work_iter.remainder() {
+            let input = match TRANSPOSED {
+                false => &[*j, *i],
+                true => &[*i, *j],
+            };
+            Shake128ForMlKem::new(&[rho, input])
+                .sample_into((&mut r.0[*offs..*offs + N]).try_into().unwrap());
         }
 
         r.reorder();
 
         r
+    }
+    fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; 256 * 4]) {
+        for (input, output) in inputs.iter().zip(outputs.chunks_exact_mut(N)) {
+            Shake128ForMlKem::new(&[rho, *input]).sample_into(output.try_into().unwrap());
+        }
     }
 
     // a * s + e
@@ -514,6 +547,18 @@ impl Coeffs<{ K * K * N }, Ntt> {
         r.inverse_ntt()
     }
 }
+
+const SAMPLE_POLY_WORK: &[(u8, u8, usize)] = &[
+    (0, 0, 0), //
+    (0, 1, N),
+    (0, 2, N * 2),
+    (1, 0, K * N),
+    (1, 1, N + K * N),
+    (1, 2, N * 2 + K * N),
+    (2, 0, K * N * 2),
+    (2, 1, N + K * N * 2),
+    (2, 2, N * 2 + K * N * 2),
+];
 
 impl Coeffs<{ K * N }, Ntt> {
     /// This is `ByteDecode_12(bytes)`.

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -28,7 +28,6 @@
 
 use core::fmt;
 use core::marker::PhantomData;
-use core::ops::Range;
 
 use crate::{Error, low};
 use crate::{
@@ -740,24 +739,45 @@ fn compress_1_x8(coeffs: &[i16; 8]) -> u8 {
 impl Coeffs<{ K * N }, Normal> {
     /// This is dual, K-wise `SamplePolyCBD`.
     ///
-    /// In other words, it produces two noise vectors.
+    /// In other words, it produces two noise vectors, diversifying the seed `sigma`
+    /// with indices from 0..2K.
     fn sample_poly_cbd_dual(sigma: &[u8; 32]) -> (Self, Self) {
-        (
-            Self::sample_poly_cbd(sigma, 0..K_BYTE),
-            Self::sample_poly_cbd(sigma, K_BYTE..K_BYTE * 2),
-        )
-    }
+        // We need 2 * K samples.
+        let mut samples = [[0; 128]; 6];
 
-    fn sample_poly_cbd(sigma: &[u8; 32], ns: Range<u8>) -> Self {
-        let mut r = Coeffs::zero();
-        let (rows, _) = r.0.as_chunks_mut();
-        let mut buf = [0u8; 128];
+        // Prepare 6 SHAKE256 inputs.
+        let mut buf = [0; 40];
+        buf[..32].copy_from_slice(sigma);
+        buf[33] = sha3::SHAKE_PAD_BYTE;
 
-        for (i, n) in ns.enumerate() {
-            sha3::Shake256::new(&[sigma, &[n]]).read(&mut buf);
-            sample_cbd2(&buf, &mut rows[i]);
+        let mut buf0 = buf;
+        let mut buf1 = buf;
+        let mut buf2 = buf;
+        let mut buf3 = buf;
+        let mut buf4 = buf;
+        let mut buf5 = buf;
+        buf0[32] = 0;
+        buf1[32] = 1;
+        buf2[32] = 2;
+        buf3[32] = 3;
+        buf4[32] = 4;
+        buf5[32] = 5;
+
+        sha3::Shake256::one_shot_sextet(&[&buf0, &buf1, &buf2, &buf3, &buf4, &buf5], &mut samples);
+
+        let mut a = Coeffs::zero();
+        let mut b = Coeffs::zero();
+
+        for (sample, poly) in samples.iter().zip(
+            a.0.as_chunks_mut()
+                .0
+                .iter_mut()
+                .chain(b.0.as_chunks_mut().0.iter_mut()),
+        ) {
+            sample_cbd2(sample, poly);
         }
-        r
+
+        (a, b)
     }
 
     /// K-wise NTT

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -847,7 +847,7 @@ fn sample_cbd2(buf: &[u8; 128], out: &mut [i16; 256]) {
 
 /// SHAKE128, but oriented at use in ML-KEM's `SampleNTT()`
 pub(crate) struct Shake128ForMlKem {
-    sponge: sha3::Shake128Sponge,
+    sponge: sha3::Shake128SqueezingSponge,
 }
 
 impl Shake128ForMlKem {
@@ -886,13 +886,13 @@ impl Shake128ForMlKem {
 
 /// Iterates over 12-bit samples drawn from `sponge`.
 struct Shake128TwelveBitIterator {
-    sponge: sha3::Shake128Sponge,
+    sponge: sha3::Shake128SqueezingSponge,
     samples: [i16; Self::SAMPLE_COUNT],
     used: usize,
 }
 
 impl Shake128TwelveBitIterator {
-    fn new(sponge: sha3::Shake128Sponge) -> Self {
+    fn new(sponge: sha3::Shake128SqueezingSponge) -> Self {
         Self {
             sponge,
             samples: [0; Self::SAMPLE_COUNT],

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -468,28 +468,59 @@ impl Coeffs<{ K * K * N }, Ntt> {
         r
     }
 
-    fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; 256 * 4]) {
-        let buf0 = prepare(rho, inputs[0]);
-        let buf1 = prepare(rho, inputs[1]);
-        let buf2 = prepare(rho, inputs[2]);
-        let buf3 = prepare(rho, inputs[3]);
+    fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; N * 4]) {
+        let mut buf = [0; 40];
+        buf[..32].copy_from_slice(rho);
+        buf[34] = sha3::SHAKE_PAD_BYTE;
 
-        let [q0, q1, q2, q3] = sha3::SqueezingSponge::shake128_new4(&[&buf0, &buf1, &buf2, &buf3]);
-        let [o0, o1, o2, o3] = outputs.as_chunks_mut().0 else {
-            unreachable!()
-        };
+        let mut buf0 = buf;
+        buf0[32..34].clone_from_slice(inputs[0]);
+        let mut buf1 = buf;
+        buf1[32..34].clone_from_slice(inputs[1]);
+        let mut buf2 = buf;
+        buf2[32..34].clone_from_slice(inputs[2]);
+        let mut buf3 = buf;
+        buf3[32..34].clone_from_slice(inputs[3]);
 
-        Shake128ForMlKem { sponge: q0 }.sample_into(o0);
-        Shake128ForMlKem { sponge: q1 }.sample_into(o1);
-        Shake128ForMlKem { sponge: q2 }.sample_into(o2);
-        Shake128ForMlKem { sponge: q3 }.sample_into(o3);
+        let sponge_4x = sha3::SqueezingSponge4xShake128::new(&[&buf0, &buf1, &buf2, &buf3]);
+        let (output0, outputs) = outputs.split_at_mut(N);
+        let (output1, outputs) = outputs.split_at_mut(N);
+        let (output2, output3) = outputs.split_at_mut(N);
 
-        fn prepare(rho: &[u8; 32], inp: &[u8; 2]) -> [u8; 40] {
-            let mut buf = [0; 40];
-            buf[..32].copy_from_slice(rho);
-            buf[32..34].copy_from_slice(inp);
-            buf[34] = sha3::SHAKE_PAD_BYTE;
-            buf
+        let mut samples = [[0; sha3::SHAKE_128_R_BYTES * 3]; 4];
+        let [tsponge0, tsponge1, tsponge2, tsponge3] = sponge_4x.squeeze(&mut samples);
+
+        let tail0 = Shake128ForMlKem::sample(&samples[0], output0.try_into().unwrap());
+        let tail1 = Shake128ForMlKem::sample(&samples[1], output1.try_into().unwrap());
+        let tail2 = Shake128ForMlKem::sample(&samples[2], output2.try_into().unwrap());
+        let tail3 = Shake128ForMlKem::sample(&samples[3], output3.try_into().unwrap());
+
+        if !tail0.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge0.restitute(),
+            }
+            .tail_case(tail0);
+        }
+
+        if !tail1.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge1.restitute(),
+            }
+            .tail_case(tail1);
+        }
+
+        if !tail2.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge2.restitute(),
+            }
+            .tail_case(tail2);
+        }
+
+        if !tail3.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge3.restitute(),
+            }
+            .tail_case(tail3);
         }
     }
 
@@ -568,6 +599,8 @@ impl Coeffs<{ K * K * N }, Ntt> {
     }
 }
 
+/// Values for i and j (pre-transpose) plus start offset of N coefficients within
+/// a K * K * N matrix.
 const SAMPLE_POLY_WORK: &[(u8, u8, usize)] = &[
     (0, 0, 0), //
     (0, 1, N),
@@ -866,12 +899,12 @@ fn sample_cbd2(buf: &[u8; 128], out: &mut [i16; 256]) {
 }
 
 /// SHAKE128, but oriented at use in ML-KEM's `SampleNTT()`
-pub(crate) struct Shake128ForMlKem {
+struct Shake128ForMlKem {
     sponge: sha3::Shake128SqueezingSponge,
 }
 
 impl Shake128ForMlKem {
-    pub(crate) fn new(message: &[&[u8]]) -> Self {
+    fn new(message: &[&[u8]]) -> Self {
         Self {
             sponge: sha3::Shake128Sponge::new_for_message(message),
         }
@@ -880,26 +913,39 @@ impl Shake128ForMlKem {
     /// Extract 256 coefficients that are < Q by rejection sampling.
     ///
     /// Refer to FIPS-203 `SampleNTT()`.  This function is the inner rejection loop.
-    pub(crate) fn sample_into(self, output: &mut [i16; 256]) {
-        let Self { mut sponge } = self;
-
+    fn sample_into(mut self, output: &mut [i16; 256]) {
         // First, we squeeze three blocks.  Each block contributes up to 112 coefficients,
         // so we get 336 candidate coefficients.
         let mut initial_bytes = [0; sha3::SHAKE_128_R_BYTES * 3];
-        sponge.squeeze(&mut initial_bytes);
+        self.sponge.squeeze(&mut initial_bytes);
 
-        // Now do rejection sampling, en bloc.
-        let used = low::mlkem_rej_uniform_vartime(output, &initial_bytes) as usize;
+        let tail = Self::sample(&initial_bytes, output);
 
         // If we were unlucky, 336 candidate coeffients weren't enough.  That
         // happens with low but not negligible probability (1 in ~120).
-        if used < output.len() {
-            let output = &mut output[used..];
-            let tail_iterator = Shake128TwelveBitIterator::new(sponge).filter(|f| *f < Q);
+        if !tail.is_empty() {
+            self.tail_case(tail);
+        }
+    }
 
-            for (out, coeff) in output.iter_mut().zip(tail_iterator) {
-                *out = coeff;
-            }
+    /// Sample into `output` using the bytes `samples`
+    ///
+    /// Returns the _unwritten_ items in output.  Call `tail_case()` with this value if
+    /// non-empty.
+    #[must_use]
+    fn sample<'a>(
+        samples: &'_ [u8; sha3::SHAKE_128_R_BYTES * 3],
+        output: &'a mut [i16; 256],
+    ) -> &'a mut [i16] {
+        let used = low::mlkem_rej_uniform_vartime(output, samples) as usize;
+        output.split_at_mut(used).1
+    }
+
+    fn tail_case(self, output: &mut [i16]) {
+        let tail_iterator = Shake128TwelveBitIterator::new(self.sponge).filter(|f| *f < Q);
+
+        for (out, coeff) in output.iter_mut().zip(tail_iterator) {
+            *out = coeff;
         }
     }
 }

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -562,6 +562,69 @@ mod tests {
     }
 
     #[test]
+    fn one_shot_sextet_matches_single() {
+        // build the six 40-byte inputs in the format `one_shot_sextet` requires:
+        // SEED || index || SHAKE_PAD_BYTE || zeroes
+        let mut inputs = [[0u8; 40]; 6];
+        for (n, inp) in inputs.iter_mut().enumerate() {
+            inp[..32].copy_from_slice(SEED);
+            inp[32] = n as u8;
+            inp[33] = SHAKE_PAD_BYTE;
+        }
+
+        let mut batched = [[0u8; 128]; 6];
+        Shake256::one_shot_sextet(
+            &[
+                &inputs[0], &inputs[1], &inputs[2], &inputs[3], &inputs[4], &inputs[5],
+            ],
+            &mut batched,
+        );
+
+        for (n, inp) in inputs.iter().enumerate() {
+            // the absorbed message is the 33 bytes preceding the pad byte
+            let mut single = [0u8; 128];
+            Shake256::new(&[&inp[..33]]).read(&mut single);
+            assert_eq!(batched[n], single);
+        }
+    }
+
+    #[test]
+    fn squeezing_sponge_4x_shake128_matches_single() {
+        // four 40-byte inputs: SEED || i || j || SHAKE_PAD_BYTE || zeroes, with each
+        // lane given a distinct message so any lane mix-up would be caught.
+        let mut inputs = [[0u8; 40]; 4];
+        for (n, inp) in inputs.iter_mut().enumerate() {
+            inp[..32].copy_from_slice(SEED);
+            inp[32] = n as u8;
+            inp[33] = (n as u8) ^ 0x5a;
+            inp[34] = SHAKE_PAD_BYTE;
+        }
+
+        // batched: three rate-blocks up front, then continue via the obligation.
+        let mut batched = [[0u8; SHAKE_128_R_BYTES * 3]; 4];
+        let obligations =
+            SqueezingSponge4xShake128::new(&[&inputs[0], &inputs[1], &inputs[2], &inputs[3]])
+                .squeeze(&mut batched);
+
+        const TAIL: usize = SHAKE_128_R_BYTES * 2;
+        for (n, (input, obligation)) in inputs.iter().zip(obligations).enumerate() {
+            // single reference: absorb the 34-byte message, read the same total length.
+            let mut single = [0u8; SHAKE_128_R_BYTES * 3 + TAIL];
+            Shake128::new(&[&input[..34]]).read(&mut single);
+
+            // the three eagerly-squeezed blocks must match
+            assert_eq!(&batched[n][..], &single[..SHAKE_128_R_BYTES * 3]);
+
+            // and paying off the deferred keccak-f must continue the same stream
+            let mut tail = [0u8; TAIL];
+            obligation.restitute().squeeze(&mut tail);
+            assert_eq!(&tail[..], &single[SHAKE_128_R_BYTES * 3..]);
+        }
+    }
+
+    const SEED: &[u8; 32] = b"Damn right its better than yours";
+
+    #[test]
     fn cavp_sha3() {
         #[derive(Debug)]
         enum Kind {

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -5,7 +5,7 @@
 //!
 //! See <https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf>
 
-use crate::low::{Blockwise, sha3_keccak_f1600};
+use crate::low::{Blockwise, sha3_keccak_f1600, sha3_keccak4_f1600};
 
 /// A context for incremental computation of SHA3-256.
 pub struct Sha3_256Context {
@@ -137,6 +137,54 @@ pub(crate) struct SqueezingSponge<const R: usize> {
 }
 
 impl<const R: usize> SqueezingSponge<R> {
+    /// Makes four new `SqueezingSponge`s by processing four SHAKE128 inputs.
+    ///
+    /// Each item of `input` shall be 40 bytes in length, which matches ML-KEM's requirements
+    /// of 34 bytes.  The 35th byte shall be `SHAKE_PAD_BYTE` and the remainder shall be zeroes.
+    pub(crate) fn shake128_new4(inputs: &[&[u8; 40]; 4]) -> [Self; 4] {
+        // This is gnarly, for the benefit of avoiding a SHAKE_128_R_BYTES-byte buffer which is
+        // mostly zeroes, and then decoding the buffer into 64-bit words.
+        let mut s = [0; 25];
+
+        s[20] = 0x8000_0000_0000_0000;
+
+        let mut r = [
+            {
+                for (i, inp) in inputs[0].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[1].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[2].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[3].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+        ];
+
+        sha3_keccak4_f1600(&mut r, &RC);
+
+        [
+            SqueezingSponge { s: r[0] },
+            SqueezingSponge { s: r[1] },
+            SqueezingSponge { s: r[2] },
+            SqueezingSponge { s: r[3] },
+        ]
+    }
+
     /// Squeeze into `output`.
     pub(crate) fn squeeze(&mut self, output: &mut [u8]) {
         for chunk in output.chunks_mut(R) {
@@ -295,7 +343,7 @@ const SHA_PAD_BYTE: u8 = 0b0000_0110;
 ///
 /// `1111` is the SHAKE domain separation constant, `1` is the multi-rate
 /// padding bit.
-const SHAKE_PAD_BYTE: u8 = 0b0001_1111;
+pub(crate) const SHAKE_PAD_BYTE: u8 = 0b0001_1111;
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -26,10 +26,10 @@ impl Sha3_256Context {
     }
 
     /// Complete the SHA3-256 computation, returning the hash output.
-    pub fn finish(mut self) -> [u8; Self::OUTPUT_SZ] {
-        self.sponge.absorb_final();
+    pub fn finish(self) -> [u8; Self::OUTPUT_SZ] {
+        let squeezing = self.sponge.absorb_final();
         let mut digest = [0u8; Self::OUTPUT_SZ];
-        self.sponge.into_single_squeeze(&mut digest);
+        squeezing.into_single_squeeze(&mut digest);
         digest
     }
 
@@ -56,10 +56,10 @@ impl Sha3_512Context {
     }
 
     /// Complete the SHA3-512 computation, returning the hash output.
-    pub fn finish(mut self) -> [u8; Self::OUTPUT_SZ] {
-        self.sponge.absorb_final();
+    pub fn finish(self) -> [u8; Self::OUTPUT_SZ] {
+        let sponge = self.sponge.absorb_final();
         let mut digest = [0u8; Self::OUTPUT_SZ];
-        self.sponge.into_single_squeeze(&mut digest);
+        sponge.into_single_squeeze(&mut digest);
         digest
     }
 
@@ -72,7 +72,7 @@ impl Sha3_512Context {
 /// This has one-shot input behaviour (all input must be provided to the
 /// constructor [`Shake128::new`]) and incremental output behaviour.
 pub struct Shake128 {
-    sponge: Sponge<SHAKE_128_R_BYTES, SHAKE_PAD_BYTE>,
+    sponge: SqueezingSponge<SHAKE_128_R_BYTES>,
     buffer: [u8; SHAKE_128_R_BYTES],
     buffer_offset: usize,
 }
@@ -83,7 +83,7 @@ impl Shake128 {
     /// The items of `message` are processed in order, as if concatenated.
     pub fn new(message: &[&[u8]]) -> Self {
         Self {
-            sponge: Sponge::new_for_message(message),
+            sponge: Sponge::<SHAKE_128_R_BYTES, SHAKE_PAD_BYTE>::new_for_message(message),
             buffer: [0u8; SHAKE_128_R_BYTES],
             buffer_offset: SHAKE_128_R_BYTES,
         }
@@ -99,13 +99,14 @@ impl Shake128 {
 }
 
 pub(crate) type Shake128Sponge = Sponge<SHAKE_128_R_BYTES, SHAKE_PAD_BYTE>;
+pub(crate) type Shake128SqueezingSponge = SqueezingSponge<SHAKE_128_R_BYTES>;
 
 /// This is SHAKE256.
 ///
 /// This has one-shot input behaviour (all input must be provided to the
 /// constructor [`Shake256::new`]) and incremental output behaviour.
 pub struct Shake256 {
-    sponge: Sponge<SHAKE_256_R_BYTES, SHAKE_PAD_BYTE>,
+    sponge: SqueezingSponge<SHAKE_256_R_BYTES>,
     buffer: [u8; SHAKE_256_R_BYTES],
     buffer_offset: usize,
 }
@@ -116,7 +117,7 @@ impl Shake256 {
     /// The items of `message` are processed in order, as if concatenated.
     pub fn new(message: &[&[u8]]) -> Self {
         Self {
-            sponge: Sponge::new_for_message(message),
+            sponge: Sponge::<SHAKE_256_R_BYTES, SHAKE_PAD_BYTE>::new_for_message(message),
             buffer: [0u8; SHAKE_256_R_BYTES],
             buffer_offset: SHAKE_256_R_BYTES,
         }
@@ -131,41 +132,29 @@ impl Shake256 {
     }
 }
 
-pub(crate) struct Sponge<const R: usize, const PAD: u8> {
+pub(crate) struct SqueezingSponge<const R: usize> {
     s: [u64; 25],
-    buffer: Blockwise<R>,
 }
 
-impl<const R: usize, const PAD: u8> Sponge<R, PAD> {
-    const fn new() -> Self {
-        Self {
-            s: [0; 25],
-            buffer: Blockwise::new(),
+impl<const R: usize> SqueezingSponge<R> {
+    /// Squeeze into `output`.
+    pub(crate) fn squeeze(&mut self, output: &mut [u8]) {
+        for chunk in output.chunks_mut(R) {
+            self.squeeze_current(chunk);
+            sha3_keccak_f1600(&mut self.s, &RC);
         }
     }
 
-    pub(crate) fn new_for_message(message: &[&[u8]]) -> Self {
-        let mut s = Self::new();
-        for m in message {
-            s.absorb(m);
-        }
-        s.absorb_final();
-        s
+    /// Squeeze into `output`, which must be below `R` in length.
+    fn into_single_squeeze(mut self, output: &mut [u8]) {
+        debug_assert!(output.len() < R);
+        self.squeeze_current(output);
     }
 
-    fn absorb(&mut self, bytes: &[u8]) {
-        let bytes = self.buffer.add_leading(bytes);
-
-        if let Some(block) = self.buffer.take() {
-            self.absorb_block(&block);
+    fn squeeze_current(&mut self, output: &mut [u8]) {
+        for (i, ch) in output.chunks_mut(8).enumerate() {
+            ch.copy_from_slice(&self.s[i].to_le_bytes()[..ch.len()]);
         }
-
-        let (blocks, remainder) = bytes.as_chunks();
-        for block in blocks {
-            self.absorb_block(block);
-        }
-
-        self.buffer.add_trailing(remainder);
     }
 
     fn shake_read(&mut self, output: &mut [u8], buffer: &mut [u8; R], buffer_offset: &mut usize) {
@@ -195,28 +184,46 @@ impl<const R: usize, const PAD: u8> Sponge<R, PAD> {
             *buffer_offset = chunk;
         }
     }
+}
 
-    /// Squeeze into `output`.
-    pub(crate) fn squeeze(&mut self, output: &mut [u8]) {
-        for chunk in output.chunks_mut(R) {
-            self.squeeze_current(chunk);
-            sha3_keccak_f1600(&mut self.s, &RC);
+pub(crate) struct Sponge<const R: usize, const PAD: u8> {
+    sponge: SqueezingSponge<R>,
+    buffer: Blockwise<R>,
+}
+
+impl<const R: usize, const PAD: u8> Sponge<R, PAD> {
+    const fn new() -> Self {
+        Self {
+            sponge: SqueezingSponge { s: [0; _] },
+            buffer: Blockwise::new(),
         }
     }
 
-    /// Squeeze into `output`, which must be below `R` in length.
-    fn into_single_squeeze(mut self, output: &mut [u8]) {
-        debug_assert!(output.len() < R);
-        self.squeeze_current(output);
-    }
-
-    fn squeeze_current(&mut self, output: &mut [u8]) {
-        for (i, ch) in output.chunks_mut(8).enumerate() {
-            ch.copy_from_slice(&self.s[i].to_le_bytes()[..ch.len()]);
+    pub(crate) fn new_for_message(message: &[&[u8]]) -> SqueezingSponge<R> {
+        let mut s = Self::new();
+        for m in message {
+            s.absorb(m);
         }
+        s.absorb_final()
     }
 
-    fn absorb_final(&mut self) {
+    fn absorb(&mut self, bytes: &[u8]) {
+        let bytes = self.buffer.add_leading(bytes);
+
+        if let Some(block) = self.buffer.take() {
+            self.absorb_block(&block);
+        }
+
+        let (blocks, remainder) = bytes.as_chunks();
+        for block in blocks {
+            self.absorb_block(block);
+        }
+
+        self.buffer.add_trailing(remainder);
+    }
+
+    #[must_use]
+    fn absorb_final(mut self) -> SqueezingSponge<R> {
         match R - self.buffer.used() {
             1 => {
                 self.buffer.add_leading(&[PAD | 0x80]);
@@ -232,13 +239,14 @@ impl<const R: usize, const PAD: u8> Sponge<R, PAD> {
         }
         let padded = self.buffer.take().unwrap();
         self.absorb_block(&padded);
+        self.sponge
     }
 
     fn absorb_block(&mut self, block: &[u8; R]) {
         for (i, block) in block.chunks_exact(8).enumerate() {
-            self.s[i] ^= u64::from_le_bytes(block.try_into().unwrap());
+            self.sponge.s[i] ^= u64::from_le_bytes(block.try_into().unwrap());
         }
-        sha3_keccak_f1600(&mut self.s, &RC);
+        sha3_keccak_f1600(&mut self.sponge.s, &RC);
     }
 }
 

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -5,6 +5,8 @@
 //!
 //! See <https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf>
 
+use core::ops::Range;
+
 use crate::low::{Blockwise, sha3_keccak_f1600, sha3_keccak4_f1600};
 
 /// A context for incremental computation of SHA3-256.
@@ -137,54 +139,6 @@ pub(crate) struct SqueezingSponge<const R: usize> {
 }
 
 impl<const R: usize> SqueezingSponge<R> {
-    /// Makes four new `SqueezingSponge`s by processing four SHAKE128 inputs.
-    ///
-    /// Each item of `input` shall be 40 bytes in length, which matches ML-KEM's requirements
-    /// of 34 bytes.  The 35th byte shall be `SHAKE_PAD_BYTE` and the remainder shall be zeroes.
-    pub(crate) fn shake128_new4(inputs: &[&[u8; 40]; 4]) -> [Self; 4] {
-        // This is gnarly, for the benefit of avoiding a SHAKE_128_R_BYTES-byte buffer which is
-        // mostly zeroes, and then decoding the buffer into 64-bit words.
-        let mut s = [0; 25];
-
-        s[20] = 0x8000_0000_0000_0000;
-
-        let mut r = [
-            {
-                for (i, inp) in inputs[0].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
-                }
-                s
-            },
-            {
-                for (i, inp) in inputs[1].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
-                }
-                s
-            },
-            {
-                for (i, inp) in inputs[2].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
-                }
-                s
-            },
-            {
-                for (i, inp) in inputs[3].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
-                }
-                s
-            },
-        ];
-
-        sha3_keccak4_f1600(&mut r, &RC);
-
-        [
-            SqueezingSponge { s: r[0] },
-            SqueezingSponge { s: r[1] },
-            SqueezingSponge { s: r[2] },
-            SqueezingSponge { s: r[3] },
-        ]
-    }
-
     /// Squeeze into `output`.
     pub(crate) fn squeeze(&mut self, output: &mut [u8]) {
         for chunk in output.chunks_mut(R) {
@@ -231,6 +185,113 @@ impl<const R: usize> SqueezingSponge<R> {
             tail.copy_from_slice(&buffer[..chunk]);
             *buffer_offset = chunk;
         }
+    }
+}
+
+pub(crate) struct SqueezingSponge4xShake128 {
+    states: [[u64; 25]; 4],
+}
+
+impl SqueezingSponge4xShake128 {
+    /// Makes four new `SqueezingSponge`s by processing four SHAKE128 inputs.
+    ///
+    /// Each item of `input` shall be 40 bytes in length, which matches ML-KEM's requirements
+    /// of 34 bytes.  The 35th byte shall be `SHAKE_PAD_BYTE` and the remainder shall be zeroes.
+    pub(crate) fn new(inputs: &[&[u8; 40]; 4]) -> Self {
+        debug_assert!(inputs.iter().all(|inp| inp[34] == SHAKE_PAD_BYTE));
+
+        // This is gnarly, for the benefit of avoiding a SHAKE_128_R_BYTES-byte buffer which is
+        // mostly zeroes, and then decoding the buffer into 64-bit words.
+        let mut s = [0; 25];
+
+        s[SHAKE_128_R_BYTES / size_of::<u64>() - 1] = 0x8000_0000_0000_0000;
+
+        let mut states = [
+            {
+                for (i, inp) in inputs[0].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[1].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[2].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[3].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+        ];
+
+        sha3_keccak4_f1600(&mut states, &RC);
+
+        Self { states }
+    }
+
+    pub(crate) fn squeeze(
+        mut self,
+        output: &mut [[u8; SHAKE_128_R_BYTES * 3]; 4],
+    ) -> [SqueezingSpongeObligation<SHAKE_128_R_BYTES>; 4] {
+        // nb. we're doing three blocks.  The states are post-absorb, so the sequence should be:
+        //
+        // - squeeze, keccak-f, squeeze, keccak-f, squeeze
+        //
+        // This leaves a trailing keccak-f owing; represented by `SqueezingSpongeObligation`.
+
+        fn squeeze_rate(
+            states: &[[u64; 25]; 4],
+            output: &mut [[u8; SHAKE_128_R_BYTES * 3]; 4],
+            span: Range<usize>,
+        ) {
+            for j in 0..4 {
+                for (i, ch) in output[j][span.clone()].chunks_mut(8).enumerate() {
+                    ch.copy_from_slice(&states[j][i].to_le_bytes());
+                }
+            }
+        }
+
+        squeeze_rate(&self.states, output, 0..SHAKE_128_R_BYTES);
+        sha3_keccak4_f1600(&mut self.states, &RC);
+        squeeze_rate(
+            &self.states,
+            output,
+            SHAKE_128_R_BYTES..SHAKE_128_R_BYTES * 2,
+        );
+        sha3_keccak4_f1600(&mut self.states, &RC);
+        squeeze_rate(
+            &self.states,
+            output,
+            SHAKE_128_R_BYTES * 2..SHAKE_128_R_BYTES * 3,
+        );
+
+        let [s0, s1, s2, s3] = self.states;
+        [
+            SqueezingSpongeObligation(s0),
+            SqueezingSpongeObligation(s1),
+            SqueezingSpongeObligation(s2),
+            SqueezingSpongeObligation(s3),
+        ]
+    }
+}
+
+/// A [`SqueezingSponge`] to which we owe a keccak-f application prior to further use.
+pub(crate) struct SqueezingSpongeObligation<const R: usize>([u64; 25]);
+
+impl<const R: usize> SqueezingSpongeObligation<R> {
+    /// Pay back the debt by applying keccak-f and return the underlying [`SqueezingSponge`]
+    pub(crate) fn restitute(mut self) -> SqueezingSponge<R> {
+        sha3_keccak_f1600(&mut self.0, &RC);
+        SqueezingSponge { s: self.0 }
     }
 }
 

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -7,7 +7,7 @@
 
 use core::ops::Range;
 
-use crate::low::{Blockwise, sha3_keccak_f1600, sha3_keccak4_f1600};
+use crate::low::{Blockwise, sha3_keccak_f1600, sha3_keccak2of4_f1600, sha3_keccak4_f1600};
 
 /// A context for incremental computation of SHA3-256.
 pub struct Sha3_256Context {
@@ -131,6 +131,82 @@ impl Shake256 {
     pub fn read(&mut self, output: &mut [u8]) {
         self.sponge
             .shake_read(output, &mut self.buffer, &mut self.buffer_offset);
+    }
+
+    /// Compute six SHAKE256 outputs in one go.
+    ///
+    /// Each item of `inputs` shall be 40 bytes in length, which accommodates ML-KEM's `SamplePolyCBD`
+    /// requirements of 33 bytes.  The 34th byte shall be `SHAKE_PAD_BYTE` and the remainder shall be
+    /// zeroes.
+    pub(crate) fn one_shot_sextet(inputs: &[&[u8; 40]; 6], outputs: &mut [[u8; 128]; 6]) {
+        debug_assert!(inputs.iter().all(|inp| inp[33] == SHAKE_PAD_BYTE));
+
+        let mut s = [0; 25];
+        s[SHAKE_256_R_BYTES / size_of::<u64>() - 1] = 0x8000_0000_0000_0000;
+
+        // First, arrange a by-4 step.
+
+        let mut states = [
+            {
+                for (i, inp) in inputs[0].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[1].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[2].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+            {
+                for (i, inp) in inputs[3].chunks_exact(8).enumerate() {
+                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                }
+                s
+            },
+        ];
+
+        sha3_keccak4_f1600(&mut states, &RC);
+        squeeze(&states[0], &mut outputs[0]);
+        squeeze(&states[1], &mut outputs[1]);
+        squeeze(&states[2], &mut outputs[2]);
+        squeeze(&states[3], &mut outputs[3]);
+
+        // Now, complete with a by-2.
+        //
+        // Note that states[2] and states[3] are unused.  This allows reuse of the
+        // by-4 keccak permutation, which is quicker on x86-64 than two by-1 keccak
+        // permutations!
+        states[0] = {
+            for (i, inp) in inputs[4].chunks_exact(8).enumerate() {
+                s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+            }
+            s
+        };
+        states[1] = {
+            for (i, inp) in inputs[5].chunks_exact(8).enumerate() {
+                s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+            }
+            s
+        };
+
+        sha3_keccak2of4_f1600(&mut states, &RC);
+        squeeze(&states[0], &mut outputs[4]);
+        squeeze(&states[1], &mut outputs[5]);
+
+        fn squeeze(states: &[u64; 25], output: &mut [u8; 128]) {
+            debug_assert!(output.len() <= SHAKE_256_R_BYTES);
+            for (i, ch) in output.chunks_mut(8).enumerate() {
+                ch.copy_from_slice(&states[i].to_le_bytes());
+            }
+        }
     }
 }
 


### PR DESCRIPTION
x86-64:

```
mlkem768-combined/graviola
                        time:   [29.886 µs 29.894 µs 29.903 µs]
                        thrpt:  [33.442 Kelem/s 33.451 Kelem/s 33.461 Kelem/s]
                 change:
                        time:   [−33.538% −32.217% −30.722%] (p = 0.00 < 0.05)
                        thrpt:  [+44.346% +47.530% +50.462%]
```

aarch64:

```
mlkem768-combined/graviola
                        time:   [24.617 µs 24.628 µs 24.639 µs]
                        thrpt:  [40.586 Kelem/s 40.604 Kelem/s 40.622 Kelem/s]
                 change:
                        time:   [−26.066% −25.898% −25.766%] (p = 0.00 < 0.05)
                        thrpt:  [+34.710% +34.949% +35.256%]
```