### PR TITLE
Use correct return type in documentation

### DIFF
--- a/graviola/src/mid/aes_gcm.rs
+++ b/graviola/src/mid/aes_gcm.rs
@@ -88,7 +88,7 @@ impl AesGcm {
     ///
     /// On success, `cipher_inout` contains the plaintext of the message,
     /// and `Ok(())` is returned.
-    /// Otherwise, `Ok(Error::DecryptFailed)` is returned and `cipher_inout`
+    /// Otherwise, `Err(Error::DecryptFailed)` is returned and `cipher_inout`
     /// is cleared.
     pub fn decrypt(
         &self,

--- a/graviola/src/mid/chacha20poly1305.rs
+++ b/graviola/src/mid/chacha20poly1305.rs
@@ -48,7 +48,7 @@ impl ChaCha20Poly1305 {
     ///
     /// On success, `cipher_inout` contains the plaintext of the message,
     /// and `Ok(())` is returned.
-    /// Otherwise, `Ok(Error::DecryptFailed)` is returned and `cipher_inout`
+    /// Otherwise, `Err(Error::DecryptFailed)` is returned and `cipher_inout`
     /// is cleared.
     pub fn decrypt(
         &self,

--- a/graviola/src/mid/xchacha20poly1305.rs
+++ b/graviola/src/mid/xchacha20poly1305.rs
@@ -48,7 +48,7 @@ impl XChaCha20Poly1305 {
     ///
     /// On success, `cipher_inout` contains the plaintext of the message,
     /// and `Ok(())` is returned.
-    /// Otherwise, `Ok(Error::DecryptFailed)` is returned and `cipher_inout`
+    /// Otherwise, `Err(Error::DecryptFailed)` is returned and `cipher_inout`
     /// is cleared.
     pub fn decrypt(
         &self,


### PR DESCRIPTION
Noticed a small oopsie in the documentation that the decrypt returns an Ok Error when actually it returns only unit on success and the error on error as it would be expected.