### PR TITLE
Enable release `debug_assertions` for Cranelift CI tests

### DIFF
--- a/.github/workflows/cranelift.yml
+++ b/.github/workflows/cranelift.yml
@@ -19,6 +19,7 @@ env:
   GRAVIOLA_CPU_DISABLE_avx512f: "1"
   GRAVIOLA_CPU_DISABLE_avx512bw: "1"
   GRAVIOLA_CPU_DISABLE_avx512vl: "1"
+  CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "true"
   # Fix AWS LC linking: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1520
   AWS_LC_SYS_NO_U1_BINDINGS: "1"
 


### PR DESCRIPTION
The `GRAVIOLA_CPU_DISABLE_X` mechanism only works when debug assertions are enabled. 

https://github.com/ctz/graviola/blob/9fc602f07ced8cb3aeab2bd5ca245f9fa6e92387/graviola/src/low/x86_64/cpu.rs#L211-L224 

cc @brian-pane 