### PR TITLE
mlkem: Improve SampleNTT performance on x86-64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,5 +65,5 @@ jobs:
         run: |
           # test software fallbacks for sha256 and sha512
           env GRAVIOLA_CPU_DISABLE_sha=1 GRAVIOLA_CPU_DISABLE_bmi2=1 cargo test
-          # test avx2/aesni aes-gcm
+          # test avx2/aesni aes-gcm & ML-KEM without avx512
           env GRAVIOLA_CPU_DISABLE_avx512bw=1 GRAVIOLA_CPU_DISABLE_avx512f=1 GRAVIOLA_CPU_DISABLE_vaes=1 cargo test

--- a/.github/workflows/cranelift.yml
+++ b/.github/workflows/cranelift.yml
@@ -19,6 +19,9 @@ env:
   GRAVIOLA_CPU_DISABLE_avx512f: "1"
   GRAVIOLA_CPU_DISABLE_avx512bw: "1"
   GRAVIOLA_CPU_DISABLE_avx512vl: "1"
+  GRAVIOLA_CPU_DISABLE_avx512vbmi: "1"
+  GRAVIOLA_CPU_DISABLE_avx512vbmi2: "1"
+  RUSTFLAGS: "--cfg cranelift"
   CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "true"
   # Fix AWS LC linking: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1520
   AWS_LC_SYS_NO_U1_BINDINGS: "1"

--- a/graviola/Cargo.toml
+++ b/graviola/Cargo.toml
@@ -27,4 +27,4 @@ serde_json = "1"
 tempfile = "3.24.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(coverage_nightly)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(coverage_nightly)", "cfg(cranelift)"] }

--- a/graviola/src/low/generic/mlkem768.rs
+++ b/graviola/src/low/generic/mlkem768.rs
@@ -1,0 +1,20 @@
+/// This does `SampleNTT()` for MLKEM768, yielding 8 polynomials worth of coefficients.
+///
+/// `inputs` are eight pre-formatted SHAKE inputs (already containing the domain separation bits.
+///
+/// `outputs` are where to write the coefficients.
+///
+/// `fallback_fn` is a complete fallback implementation of the whole function, reading `inputs` and
+/// writing `outputs`.  It does not require `tail_fn`.
+///
+/// `tail_fn` takes a keccak state (which requires an immedate permutation prior to use) and a set
+/// of "tail" coefficients which need to be filled via sampling the SHAKE output in the usual way.
+/// This is called in uncommon situations.
+pub(crate) fn mlkem768_sample_poly_ntt_8x(
+    inputs: &[[u8; 40]; 8],
+    outputs: &mut [i16; 256 * 8],
+    fallback_fn: fn(&[[u8; 40]; 8], &mut [i16; 256 * 8]),
+    _tail_fn: fn(&mut [u64; 25], &mut [i16]),
+) {
+    fallback_fn(inputs, outputs)
+}

--- a/graviola/src/low/generic/mlkem768.rs
+++ b/graviola/src/low/generic/mlkem768.rs
@@ -1,3 +1,6 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
 /// This does `SampleNTT()` for MLKEM768, yielding 8 polynomials worth of coefficients.
 ///
 /// `inputs` are eight pre-formatted SHAKE inputs (already containing the domain separation bits.

--- a/graviola/src/low/mod.rs
+++ b/graviola/src/low/mod.rs
@@ -19,6 +19,7 @@ mod generic {
     pub(crate) mod ghash;
     #[cfg(target_arch = "aarch64")]
     pub(crate) mod mlkem;
+    #[cfg(any(cranelift, target_arch = "aarch64"))]
     pub(crate) mod mlkem768;
     pub(crate) mod poly1305;
     #[cfg(target_arch = "x86_64")]
@@ -115,6 +116,12 @@ cfg_if::cfg_if! {
         pub(crate) use x86_64::mlkem_tobytes::mlkem_tobytes;
         pub(crate) use x86_64::mlkem_tomont::mlkem_tomont;
         pub(crate) use x86_64::mlkem_unpack::mlkem_unpack;
+        #[cfg(not(cranelift))]
+        pub(crate) use x86_64::mlkem768_sample_poly_ntt_8x::mlkem768_sample_poly_ntt_8x;
+
+        #[cfg(cranelift)]
+        pub(crate) use generic::mlkem768::mlkem768_sample_poly_ntt_8x;
+
         pub(crate) use x86_64::p256_montjadd::p256_montjadd;
         pub(crate) use x86_64::p256_montjdouble::p256_montjdouble;
         pub(crate) use x86_64::p256_montjmixadd::p256_montjmixadd;
@@ -126,7 +133,6 @@ cfg_if::cfg_if! {
         pub(crate) use x86_64::sha3_keccak4_f1600_shim::sha3_keccak4_f1600;
         pub(crate) use x86_64::sha3_keccak2of4_f1600::sha3_keccak2of4_f1600;
 
-        pub(crate) use generic::mlkem768::mlkem768_sample_poly_ntt_8x;
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
 

--- a/graviola/src/low/mod.rs
+++ b/graviola/src/low/mod.rs
@@ -19,6 +19,7 @@ mod generic {
     pub(crate) mod ghash;
     #[cfg(target_arch = "aarch64")]
     pub(crate) mod mlkem;
+    pub(crate) mod mlkem768;
     pub(crate) mod poly1305;
     #[cfg(target_arch = "x86_64")]
     pub(super) mod sha256;
@@ -124,6 +125,8 @@ cfg_if::cfg_if! {
         pub(crate) use x86_64::sha3_keccak_f1600::sha3_keccak_f1600;
         pub(crate) use x86_64::sha3_keccak4_f1600_shim::sha3_keccak4_f1600;
         pub(crate) use x86_64::sha3_keccak2of4_f1600::sha3_keccak2of4_f1600;
+
+        pub(crate) use generic::mlkem768::mlkem768_sample_poly_ntt_8x;
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
 
@@ -206,6 +209,7 @@ cfg_if::cfg_if! {
         pub(crate) use generic::chacha20;
         pub(crate) use generic::sha512::sha512_compress_blocks;
         pub(crate) use generic::mlkem::{mlkem_frombytes, mlkem_unpack};
+        pub(crate) use generic::mlkem768::mlkem768_sample_poly_ntt_8x;
     } else {
         compile_error!("This crate only supports x86_64 or aarch64");
     }

--- a/graviola/src/low/x86_64/cpu.rs
+++ b/graviola/src/low/x86_64/cpu.rs
@@ -154,6 +154,12 @@ macro_rules! have_cpu_feature {
     ("avx512vl") => {
         crate::low::x86_64::cpu::test_toggle("avx512vl", is_x86_feature_detected!("avx512vl"))
     };
+    ("avx512vbmi") => {
+        crate::low::x86_64::cpu::test_toggle("avx512vbmi", is_x86_feature_detected!("avx512vbmi"))
+    };
+    ("avx512vbmi2") => {
+        crate::low::x86_64::cpu::test_toggle("avx512vbmi2", is_x86_feature_detected!("avx512vbmi2"))
+    };
     ("sha") => {
         crate::low::x86_64::cpu::test_toggle("sha", is_x86_feature_detected!("sha"))
     };
@@ -172,6 +178,25 @@ impl HaveAvx512ForAesGcm {
             && have_cpu_feature!("avx512vl")
             && have_cpu_feature!("vpclmulqdq")
             && have_cpu_feature!("vaes")
+        {
+            true => Some(Self(())),
+            false => None,
+        }
+    }
+}
+
+/// Token type reflecting the check for CPU features needed for AVX512-ML-KEM
+///
+/// A value of this type is proof that the CPU dynamic feature check has happened.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HaveAvx512ForMlKem(());
+
+impl HaveAvx512ForMlKem {
+    pub(crate) fn check() -> Option<Self> {
+        match have_cpu_feature!("avx512f")
+            && have_cpu_feature!("avx512bw")
+            && have_cpu_feature!("avx512vbmi")
+            && have_cpu_feature!("avx512vbmi2")
         {
             true => Some(Self(())),
             false => None,

--- a/graviola/src/low/x86_64/mlkem768_sample_poly_ntt_8x.rs
+++ b/graviola/src/low/x86_64/mlkem768_sample_poly_ntt_8x.rs
@@ -3,7 +3,7 @@
 
 use core::{arch::x86_64::*, ops::Range};
 
-use super::cpu::HaveAvx512ForAesGcm;
+use super::cpu::HaveAvx512ForMlKem;
 
 pub(crate) fn mlkem768_sample_poly_ntt_8x(
     inputs: &[[u8; 40]; 8],
@@ -11,8 +11,8 @@ pub(crate) fn mlkem768_sample_poly_ntt_8x(
     fallback_fn: fn(&[[u8; 40]; 8], &mut [i16; 256 * 8]),
     tail_fn: fn(&mut [u64; 25], &mut [i16]),
 ) {
-    match HaveAvx512ForAesGcm::check() {
-        // SAFETY: `HaveAvx512ForAesGcm` checks for required target features
+    match HaveAvx512ForMlKem::check() {
+        // SAFETY: `HaveAvx512ForMlKem` checks for required target features
         Some(proof) => unsafe { sample_poly_ntt_8x_avx512(inputs, outputs, tail_fn, proof) },
         None => fallback_fn(inputs, outputs),
     }
@@ -23,7 +23,7 @@ unsafe fn sample_poly_ntt_8x_avx512(
     inputs: &[[u8; 40]; 8],
     outputs: &mut [i16; 256 * 8],
     tail_fn: fn(&mut [u64; 25], &mut [i16]),
-    _proof: HaveAvx512ForAesGcm,
+    _proof: HaveAvx512ForMlKem,
 ) {
     let mut keccak_states = [_mm512_setzero_si512(); 25];
 

--- a/graviola/src/low/x86_64/mlkem768_sample_poly_ntt_8x.rs
+++ b/graviola/src/low/x86_64/mlkem768_sample_poly_ntt_8x.rs
@@ -18,7 +18,7 @@ pub(crate) fn mlkem768_sample_poly_ntt_8x(
     }
 }
 
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vbmi,avx512vbmi2")]
 unsafe fn sample_poly_ntt_8x_avx512(
     inputs: &[[u8; 40]; 8],
     outputs: &mut [i16; 256 * 8],
@@ -192,18 +192,29 @@ fn extract_state(states: &[__m512i; 25], index: usize) -> [u64; 25] {
 ///
 /// `left` indicates how many items in each polynomial in `output` remains unwritten.
 /// It should be updated to indicate how many were written.
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vbmi,avx512vbmi2")]
 fn _squeeze_rate_and_reject(
     state: &[__m512i; 25],
     output: &mut [i16; 256 * 8],
     left: &mut [usize; 8],
 ) {
-    // De-interleave the rate lanes, so `rate[lane][i]` is `lane` of the `i`th state.
     let mut rate = [[0u64; 8]; RATE_WORDS];
     for (lane, out) in rate.iter_mut().enumerate() {
         // SAFETY: `out` is 8 * 8 = 64 bytes, exactly the width of one `__m512i`.
         unsafe { _mm512_storeu_si512(out.as_mut_ptr().cast(), state[lane]) };
     }
+
+    // SAFETY: `SPREAD` is 64 bytes, exactly the width of one `__m512i`.
+    let spread = unsafe { _mm512_loadu_si512(SPREAD.as_ptr().cast()) };
+
+    let q = _mm512_set1_epi16(Q as i16);
+    let twelve_bits = _mm512_set1_epi16(0x0fff);
+
+    // Within each pair of 16-bit lanes, the first candidate needs no shift and the
+    // second needs to lose the four bits it shares with the first.
+    let shifts = _mm512_set1_epi32(0x0004_0000);
+
+    let mut bytes = [0u8; RATE_BYTES + 64];
 
     for (i, (left, poly)) in left
         .iter_mut()
@@ -215,35 +226,56 @@ fn _squeeze_rate_and_reject(
         }
 
         // Collect this state's rate bytes.  Candidates straddle the 64-bit lanes,
-        // so it is simplest to linearise them first.
-        let mut bytes = [0u8; RATE_WORDS * 8];
-        for (lane, chunk) in bytes.chunks_exact_mut(8).enumerate() {
+        // so it is simplest to linearise them first.  The trailing padding means a
+        // 64-byte load from anywhere within the rate stays in bounds.
+        for (lane, chunk) in bytes[..RATE_BYTES].chunks_exact_mut(8).enumerate() {
             chunk.copy_from_slice(&rate[lane][i].to_le_bytes());
         }
 
-        // Rejection sample, per FIPS-203 `SampleNTT()`: each three bytes give two
-        // 12-bit candidates, each accepted if less than Q.
         let mut used = 256 - *left;
 
-        for triple in bytes.chunks_exact(3) {
+        for offset in (0..RATE_BYTES).step_by(GROUP_BYTES) {
             if used == 256 {
                 break;
             }
 
-            let d1 = u16::from(triple[0]) | (u16::from(triple[1] & 0x0f) << 8);
-            if d1 < Q {
-                poly[used] = d1 as i16;
-                used += 1;
+            // Rejection sample, per FIPS-203 `SampleNTT()`: each three bytes give two
+            // 12-bit candidates.  `SPREAD` gathers each three-byte group into a pair
+            // of 16-bit lanes, which are then reduced to the candidates themselves.
+            // SAFETY: `bytes` is padded to allow a 64-byte load from `offset`.
+            let raw = unsafe { _mm512_loadu_si512(bytes[offset..].as_ptr().cast()) };
+            let candidates = _mm512_and_si512(
+                _mm512_srlv_epi16(_mm512_permutexvar_epi8(spread, raw), shifts),
+                twelve_bits,
+            );
+
+            // Accept candidates less than Q.  Lanes past the end of the rate read as
+            // zero, which would otherwise be accepted, so discard them.
+            let mut accept = _mm512_cmplt_epu16_mask(candidates, q);
+            let valid = ((RATE_BYTES - offset) / 3 * 2).min(GROUP_CANDIDATES);
+            if valid < GROUP_CANDIDATES {
+                accept &= (1u32 << valid) - 1;
             }
 
-            if used == 256 {
-                break;
-            }
+            let accepted = accept.count_ones() as usize;
 
-            let d2 = (u16::from(triple[1]) >> 4) | (u16::from(triple[2]) << 4);
-            if d2 < Q {
-                poly[used] = d2 as i16;
-                used += 1;
+            if used + GROUP_CANDIDATES <= 256 {
+                // Compaction cannot overrun `poly`, so write straight into it.
+                // SAFETY: `accepted` is at most `GROUP_CANDIDATES`, which fits.
+                unsafe {
+                    _mm512_mask_compressstoreu_epi16(poly[used..].as_mut_ptr(), accept, candidates)
+                };
+                used += accepted;
+            } else {
+                // Otherwise compact aside, and take only as much as fits.
+                let mut scratch = [0i16; GROUP_CANDIDATES];
+                // SAFETY: `accepted` is at most `GROUP_CANDIDATES`, the size of `scratch`.
+                unsafe {
+                    _mm512_mask_compressstoreu_epi16(scratch.as_mut_ptr(), accept, candidates)
+                };
+                let take = accepted.min(256 - used);
+                poly[used..used + take].copy_from_slice(&scratch[..take]);
+                used += take;
             }
         }
 
@@ -253,6 +285,34 @@ fn _squeeze_rate_and_reject(
 
 /// SHAKE128's rate, in 64-bit words: 168 bytes.
 const RATE_WORDS: usize = (1600 - 256) / 64;
+
+/// SHAKE128's rate, in bytes.
+const RATE_BYTES: usize = RATE_WORDS * 8;
+
+/// Candidates produced by one vector pass.
+const GROUP_CANDIDATES: usize = 32;
+
+/// Bytes consumed by one vector pass; three bytes give two candidates.
+const GROUP_BYTES: usize = GROUP_CANDIDATES / 2 * 3;
+
+/// Byte permutation spreading `GROUP_BYTES` packed bytes into 32 16-bit lanes.
+///
+/// Lane `k` (where `j = k / 2`) takes bytes `3j` and `3j + 1` when `k` is even,
+/// or `3j + 1` and `3j + 2` when it is odd.
+static SPREAD: [u8; 64] = {
+    let mut r = [0u8; 64];
+    let mut k = 0;
+    while k < GROUP_CANDIDATES {
+        let low = match k % 2 {
+            0 => 3 * (k / 2),
+            _ => 3 * (k / 2) + 1,
+        };
+        r[k * 2] = low as u8;
+        r[k * 2 + 1] = (low + 1) as u8;
+        k += 1;
+    }
+    r
+};
 
 /// The ML-KEM prime.
 const Q: u16 = 3329;

--- a/graviola/src/low/x86_64/mlkem768_sample_poly_ntt_8x.rs
+++ b/graviola/src/low/x86_64/mlkem768_sample_poly_ntt_8x.rs
@@ -1,0 +1,258 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+use core::{arch::x86_64::*, ops::Range};
+
+use super::cpu::HaveAvx512ForAesGcm;
+
+pub(crate) fn mlkem768_sample_poly_ntt_8x(
+    inputs: &[[u8; 40]; 8],
+    outputs: &mut [i16; 256 * 8],
+    fallback_fn: fn(&[[u8; 40]; 8], &mut [i16; 256 * 8]),
+    tail_fn: fn(&mut [u64; 25], &mut [i16]),
+) {
+    match HaveAvx512ForAesGcm::check() {
+        // SAFETY: `HaveAvx512ForAesGcm` checks for required target features
+        Some(proof) => unsafe { sample_poly_ntt_8x_avx512(inputs, outputs, tail_fn, proof) },
+        None => fallback_fn(inputs, outputs),
+    }
+}
+
+#[target_feature(enable = "avx512f")]
+unsafe fn sample_poly_ntt_8x_avx512(
+    inputs: &[[u8; 40]; 8],
+    outputs: &mut [i16; 256 * 8],
+    tail_fn: fn(&mut [u64; 25], &mut [i16]),
+    _proof: HaveAvx512ForAesGcm,
+) {
+    let mut keccak_states = [_mm512_setzero_si512(); 25];
+
+    keccak_states[20] = _mm512_set1_epi64(0x8000_0000_0000_0000_u64 as i64);
+
+    let word = |i: usize, range: Range<usize>| {
+        u64::from_le_bytes(inputs[i][range].try_into().unwrap()) as i64
+    };
+    for (i, state) in keccak_states[..5].iter_mut().enumerate() {
+        *state = _mm512_setr_epi64(
+            word(0, i * 8..(i + 1) * 8),
+            word(1, i * 8..(i + 1) * 8),
+            word(2, i * 8..(i + 1) * 8),
+            word(3, i * 8..(i + 1) * 8),
+            word(4, i * 8..(i + 1) * 8),
+            word(5, i * 8..(i + 1) * 8),
+            word(6, i * 8..(i + 1) * 8),
+            word(7, i * 8..(i + 1) * 8),
+        );
+    }
+
+    // This tracks the number of unwritten coefficients in each output polynomial.
+    let mut left = [256; 8];
+
+    // Like the generic version, we generate three squeezes of data to
+    // sample coefficients from.  This gives up to 336 candidates for 256 output
+    // coefficients.
+    _sha3_keccak8_f1600(&mut keccak_states, &RC);
+    _squeeze_rate_and_reject(&keccak_states, outputs, &mut left);
+    _sha3_keccak8_f1600(&mut keccak_states, &RC);
+    _squeeze_rate_and_reject(&keccak_states, outputs, &mut left);
+    _sha3_keccak8_f1600(&mut keccak_states, &RC);
+    _squeeze_rate_and_reject(&keccak_states, outputs, &mut left);
+
+    for (i, (left, output)) in left.iter().zip(outputs.chunks_exact_mut(256)).enumerate() {
+        if *left > 0 {
+            let mut state = extract_state(&keccak_states, i);
+            tail_fn(&mut state, &mut output[256 - *left..]);
+        }
+    }
+}
+
+#[target_feature(enable = "avx512f")]
+fn _sha3_keccak8_f1600(state: &mut [__m512i; 25], rc: &[u64; 24]) {
+    for round_constant in rc {
+        // Theta step.
+        //
+        // Compute the column parities C[x], then D[x] = C[x-1] ^ ROL(C[x+1], 1),
+        // and fold D[x] into every lane of column x.
+        let mut c = [_mm512_setzero_si512(); 5];
+        for x in 0..5 {
+            c[x] = xor(
+                xor(
+                    xor(state[x], state[x + 5]),
+                    xor(state[x + 10], state[x + 15]),
+                ),
+                state[x + 20],
+            );
+        }
+
+        let mut d = [_mm512_setzero_si512(); 5];
+        for x in 0..5 {
+            d[x] = xor(c[(x + 4) % 5], rotate_left(c[(x + 1) % 5], 1));
+        }
+
+        for x in 0..5 {
+            for y in 0..5 {
+                state[x + 5 * y] = xor(state[x + 5 * y], d[x]);
+            }
+        }
+
+        // Rho and Pi steps.
+        //
+        // Rotate each lane by its rho offset and scatter it to its pi position
+        // B[y, 2x + 3y] = ROL(A[x, y], RHO[x][y]).
+        let mut b = [_mm512_setzero_si512(); 25];
+        for x in 0..5 {
+            for y in 0..5 {
+                b[y + 5 * ((2 * x + 3 * y) % 5)] = rotate_left(state[x + 5 * y], RHO[x][y]);
+            }
+        }
+
+        // Chi step.
+        //
+        // A[x, y] = B[x, y] ^ ((~B[x+1, y]) & B[x+2, y]).
+        for x in 0..5 {
+            for y in 0..5 {
+                state[x + 5 * y] = xor(
+                    b[x + 5 * y],
+                    _mm512_andnot_si512(b[(x + 1) % 5 + 5 * y], b[(x + 2) % 5 + 5 * y]),
+                );
+            }
+        }
+
+        // Iota step.
+        state[0] = xor(state[0], _mm512_set1_epi64(*round_constant as i64));
+    }
+}
+
+/// Rotation offsets for the rho step, indexed `RHO[x][y]`.
+static RHO: [[i32; 5]; 5] = [
+    [0, 36, 3, 41, 18],
+    [1, 44, 10, 45, 2],
+    [62, 6, 43, 15, 61],
+    [28, 55, 25, 21, 56],
+    [27, 20, 39, 8, 14],
+];
+
+const RC: [u64; 24] = [
+    0x00000000_00000001,
+    0x00000000_00008082,
+    0x80000000_0000808A,
+    0x80000000_80008000,
+    0x00000000_0000808B,
+    0x00000000_80000001,
+    0x80000000_80008081,
+    0x80000000_00008009,
+    0x00000000_0000008A,
+    0x00000000_00000088,
+    0x00000000_80008009,
+    0x00000000_8000000A,
+    0x00000000_8000808B,
+    0x80000000_0000008B,
+    0x80000000_00008089,
+    0x80000000_00008003,
+    0x80000000_00008002,
+    0x80000000_00000080,
+    0x00000000_0000800A,
+    0x80000000_8000000A,
+    0x80000000_80008081,
+    0x80000000_00008080,
+    0x00000000_80000001,
+    0x80000000_80008008,
+];
+
+#[inline]
+#[target_feature(enable = "avx512f")]
+fn xor(a: __m512i, b: __m512i) -> __m512i {
+    _mm512_xor_si512(a, b)
+}
+
+/// Rotate each 64-bit lane of `x` left by `n` bits, where `n` is in `0..64`.
+#[inline]
+#[target_feature(enable = "avx512f")]
+fn rotate_left(x: __m512i, n: i32) -> __m512i {
+    _mm512_rolv_epi64(x, _mm512_set1_epi64(n as i64))
+}
+
+/// Extract a single keccak state from the 8-way `states`, where `index` is in `0..8`.
+///
+/// `states[lane]` holds `lane` for all eight states, so the result collects the
+/// `index`th 64-bit word of each lane.
+#[target_feature(enable = "avx512f")]
+fn extract_state(states: &[__m512i; 25], index: usize) -> [u64; 25] {
+    let mut r = [0u64; 25];
+    for (lane, out) in r.iter_mut().enumerate() {
+        let mut words = [0u64; 8];
+        // SAFETY: `words` is 8 * 8 = 64 bytes, exactly the width of one `__m512i`.
+        unsafe { _mm512_storeu_si512(words.as_mut_ptr().cast(), states[lane]) };
+        *out = words[index];
+    }
+    r
+}
+
+/// Squeeze rate bytes from `state`, rejection sampling into `output`.
+///
+/// `left` indicates how many items in each polynomial in `output` remains unwritten.
+/// It should be updated to indicate how many were written.
+#[target_feature(enable = "avx512f")]
+fn _squeeze_rate_and_reject(
+    state: &[__m512i; 25],
+    output: &mut [i16; 256 * 8],
+    left: &mut [usize; 8],
+) {
+    // De-interleave the rate lanes, so `rate[lane][i]` is `lane` of the `i`th state.
+    let mut rate = [[0u64; 8]; RATE_WORDS];
+    for (lane, out) in rate.iter_mut().enumerate() {
+        // SAFETY: `out` is 8 * 8 = 64 bytes, exactly the width of one `__m512i`.
+        unsafe { _mm512_storeu_si512(out.as_mut_ptr().cast(), state[lane]) };
+    }
+
+    for (i, (left, poly)) in left
+        .iter_mut()
+        .zip(output.chunks_exact_mut(256))
+        .enumerate()
+    {
+        if *left == 0 {
+            continue;
+        }
+
+        // Collect this state's rate bytes.  Candidates straddle the 64-bit lanes,
+        // so it is simplest to linearise them first.
+        let mut bytes = [0u8; RATE_WORDS * 8];
+        for (lane, chunk) in bytes.chunks_exact_mut(8).enumerate() {
+            chunk.copy_from_slice(&rate[lane][i].to_le_bytes());
+        }
+
+        // Rejection sample, per FIPS-203 `SampleNTT()`: each three bytes give two
+        // 12-bit candidates, each accepted if less than Q.
+        let mut used = 256 - *left;
+
+        for triple in bytes.chunks_exact(3) {
+            if used == 256 {
+                break;
+            }
+
+            let d1 = u16::from(triple[0]) | (u16::from(triple[1] & 0x0f) << 8);
+            if d1 < Q {
+                poly[used] = d1 as i16;
+                used += 1;
+            }
+
+            if used == 256 {
+                break;
+            }
+
+            let d2 = (u16::from(triple[1]) >> 4) | (u16::from(triple[2]) << 4);
+            if d2 < Q {
+                poly[used] = d2 as i16;
+                used += 1;
+            }
+        }
+
+        *left = 256 - used;
+    }
+}
+
+/// SHAKE128's rate, in 64-bit words: 168 bytes.
+const RATE_WORDS: usize = (1600 - 256) / 64;
+
+/// The ML-KEM prime.
+const Q: u16 = 3329;

--- a/graviola/src/low/x86_64/mod.rs
+++ b/graviola/src/low/x86_64/mod.rs
@@ -62,6 +62,8 @@ pub(crate) mod edwards25519_scalarmulbase;
 pub(crate) mod edwards25519_scalarmuldouble;
 pub(crate) mod ghash;
 pub(crate) mod mlkem;
+#[cfg(not(cranelift))]
+pub(crate) mod mlkem768_sample_poly_ntt_8x;
 pub(crate) mod mlkem_basemul_k3;
 pub(crate) mod mlkem_frombytes;
 pub(crate) mod mlkem_intt;

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -38,6 +38,8 @@ use crate::{
     },
 };
 
+mod sample_ntt;
+
 /// An ML-KEM-768 decapsulation key.
 pub struct DecapKey {
     ek_pke: EncapKey,
@@ -410,113 +412,15 @@ impl<const C: usize, D: Domain> Coeffs<C, D> {
 
 impl Coeffs<{ K * K * N }, Ntt> {
     fn sample_poly(rho: &[u8; 32]) -> Self {
-        Self::_sample_poly_ntt::<false>(rho)
-    }
-
-    fn sample_poly_transposed(rho: &[u8; 32]) -> Self {
-        Self::_sample_poly_ntt::<true>(rho)
-    }
-
-    fn _sample_poly_ntt<const TRANSPOSED: bool>(rho: &[u8; 32]) -> Self {
-        let mut r = Coeffs::zero();
-
-        // We have K * K polynomials to generate.  In this case, K := 3, so 9.
-        // We have a by-4 keccak, so we can attack the problem in two
-        // sets of four, followed by one straggler.
-
-        let mut work_iter = SAMPLE_POLY_WORK.chunks_exact(4);
-
-        for c4 in work_iter.by_ref() {
-            let inputs = match TRANSPOSED {
-                false => &[
-                    &[c4[0].1, c4[0].0],
-                    &[c4[1].1, c4[1].0],
-                    &[c4[2].1, c4[2].0],
-                    &[c4[3].1, c4[3].0],
-                ],
-                true => &[
-                    &[c4[0].0, c4[0].1],
-                    &[c4[1].0, c4[1].1],
-                    &[c4[2].0, c4[2].1],
-                    &[c4[3].0, c4[3].1],
-                ],
-            };
-
-            Self::_sample_poly_ntt_quad(
-                rho,
-                inputs,
-                (&mut r.0[c4[0].2..c4[3].2 + N]).try_into().unwrap(),
-            );
-        }
-
-        for (i, j, offs) in work_iter.remainder() {
-            let input = match TRANSPOSED {
-                false => &[*j, *i],
-                true => &[*i, *j],
-            };
-            Shake128ForMlKem::new(&[rho, input])
-                .sample_into((&mut r.0[*offs..*offs + N]).try_into().unwrap());
-        }
-
+        let mut r = Self(sample_ntt::sample_ntt(rho), PhantomData);
         r.reorder();
-
         r
     }
 
-    fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; N * 4]) {
-        let mut buf = [0; 40];
-        buf[..32].copy_from_slice(rho);
-        buf[34] = sha3::SHAKE_PAD_BYTE;
-
-        let mut buf0 = buf;
-        buf0[32..34].clone_from_slice(inputs[0]);
-        let mut buf1 = buf;
-        buf1[32..34].clone_from_slice(inputs[1]);
-        let mut buf2 = buf;
-        buf2[32..34].clone_from_slice(inputs[2]);
-        let mut buf3 = buf;
-        buf3[32..34].clone_from_slice(inputs[3]);
-
-        let sponge_4x = sha3::SqueezingSponge4xShake128::new(&[&buf0, &buf1, &buf2, &buf3]);
-        let (output0, outputs) = outputs.split_at_mut(N);
-        let (output1, outputs) = outputs.split_at_mut(N);
-        let (output2, output3) = outputs.split_at_mut(N);
-
-        let mut samples = [[0; sha3::SHAKE_128_R_BYTES * 3]; 4];
-        let [tsponge0, tsponge1, tsponge2, tsponge3] = sponge_4x.squeeze(&mut samples);
-
-        let tail0 = Shake128ForMlKem::sample(&samples[0], output0.try_into().unwrap());
-        let tail1 = Shake128ForMlKem::sample(&samples[1], output1.try_into().unwrap());
-        let tail2 = Shake128ForMlKem::sample(&samples[2], output2.try_into().unwrap());
-        let tail3 = Shake128ForMlKem::sample(&samples[3], output3.try_into().unwrap());
-
-        if !tail0.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge0.restitute(),
-            }
-            .tail_case(tail0);
-        }
-
-        if !tail1.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge1.restitute(),
-            }
-            .tail_case(tail1);
-        }
-
-        if !tail2.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge2.restitute(),
-            }
-            .tail_case(tail2);
-        }
-
-        if !tail3.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge3.restitute(),
-            }
-            .tail_case(tail3);
-        }
+    fn sample_poly_transposed(rho: &[u8; 32]) -> Self {
+        let mut r = Self(sample_ntt::sample_ntt_transposed(rho), PhantomData);
+        r.reorder();
+        r
     }
 
     // a * s + e
@@ -593,20 +497,6 @@ impl Coeffs<{ K * K * N }, Ntt> {
         r.inverse_ntt()
     }
 }
-
-/// Values for i and j (pre-transpose) plus start offset of N coefficients within
-/// a K * K * N matrix.
-const SAMPLE_POLY_WORK: &[(u8, u8, usize)] = &[
-    (0, 0, 0), //
-    (0, 1, N),
-    (0, 2, N * 2),
-    (1, 0, K * N),
-    (1, 1, N + K * N),
-    (1, 2, N * 2 + K * N),
-    (2, 0, K * N * 2),
-    (2, 1, N + K * N * 2),
-    (2, 2, N * 2 + K * N * 2),
-];
 
 impl Coeffs<{ K * N }, Ntt> {
     /// This is `ByteDecode_12(bytes)`.
@@ -921,100 +811,6 @@ fn sample_cbd2(buf: &[u8; 128], out: &mut [i16; 256]) {
             let b = ((d >> (4 * j + 2)) & 0x3) as i16;
             *coeff = a - b;
         }
-    }
-}
-
-/// SHAKE128, but oriented at use in ML-KEM's `SampleNTT()`
-struct Shake128ForMlKem {
-    sponge: sha3::Shake128SqueezingSponge,
-}
-
-impl Shake128ForMlKem {
-    fn new(message: &[&[u8]]) -> Self {
-        Self {
-            sponge: sha3::Shake128Sponge::new_for_message(message),
-        }
-    }
-
-    /// Extract 256 coefficients that are < Q by rejection sampling.
-    ///
-    /// Refer to FIPS-203 `SampleNTT()`.  This function is the inner rejection loop.
-    fn sample_into(mut self, output: &mut [i16; 256]) {
-        // First, we squeeze three blocks.  Each block contributes up to 112 coefficients,
-        // so we get 336 candidate coefficients.
-        let mut initial_bytes = [0; sha3::SHAKE_128_R_BYTES * 3];
-        self.sponge.squeeze(&mut initial_bytes);
-
-        let tail = Self::sample(&initial_bytes, output);
-
-        // If we were unlucky, 336 candidate coeffients weren't enough.  That
-        // happens with low but not negligible probability (1 in ~120).
-        if !tail.is_empty() {
-            self.tail_case(tail);
-        }
-    }
-
-    /// Sample into `output` using the bytes `samples`
-    ///
-    /// Returns the _unwritten_ items in output.  Call `tail_case()` with this value if
-    /// non-empty.
-    #[must_use]
-    fn sample<'a>(
-        samples: &'_ [u8; sha3::SHAKE_128_R_BYTES * 3],
-        output: &'a mut [i16; 256],
-    ) -> &'a mut [i16] {
-        let used = low::mlkem_rej_uniform_vartime(output, samples) as usize;
-        output.split_at_mut(used).1
-    }
-
-    fn tail_case(self, output: &mut [i16]) {
-        let tail_iterator = Shake128TwelveBitIterator::new(self.sponge).filter(|f| *f < Q);
-
-        for (out, coeff) in output.iter_mut().zip(tail_iterator) {
-            *out = coeff;
-        }
-    }
-}
-
-/// Iterates over 12-bit samples drawn from `sponge`.
-struct Shake128TwelveBitIterator {
-    sponge: sha3::Shake128SqueezingSponge,
-    samples: [i16; Self::SAMPLE_COUNT],
-    used: usize,
-}
-
-impl Shake128TwelveBitIterator {
-    fn new(sponge: sha3::Shake128SqueezingSponge) -> Self {
-        Self {
-            sponge,
-            samples: [0; Self::SAMPLE_COUNT],
-            used: Self::SAMPLE_COUNT,
-        }
-    }
-
-    /// Each three bytes of SHAKE output yields two coefficients.
-    const SAMPLE_COUNT: usize = sha3::SHAKE_128_R_BYTES / 3 * 2;
-}
-
-impl Iterator for Shake128TwelveBitIterator {
-    type Item = i16;
-
-    #[cold]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.used == self.samples.len() {
-            let mut bytes = [0u8; sha3::SHAKE_128_R_BYTES];
-            self.sponge.squeeze(&mut bytes);
-
-            for (buf, d) in bytes.chunks_exact(3).zip(self.samples.chunks_exact_mut(2)) {
-                d[0] = (u16::from_le_bytes([buf[0], buf[1]]) & 0xfff) as i16;
-                d[1] = (u16::from_le_bytes([buf[1], buf[2]]) >> 4) as i16;
-            }
-            self.used = 0;
-        }
-
-        let item = self.samples[self.used];
-        self.used += 1;
-        Some(item)
     }
 }
 

--- a/graviola/src/mid/mlkem768/sample_ntt.rs
+++ b/graviola/src/mid/mlkem768/sample_ntt.rs
@@ -1,0 +1,220 @@
+// Written for Graviola by Joe Birr-Pixton, 2026.
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+use crate::{low, mid::sha3};
+
+pub(super) fn sample_ntt(rho: &[u8; 32]) -> [i16; K * K * N] {
+    _sample_ntt::<false>(rho)
+}
+
+pub(super) fn sample_ntt_transposed(rho: &[u8; 32]) -> [i16; K * K * N] {
+    _sample_ntt::<true>(rho)
+}
+
+fn _sample_ntt<const TRANSPOSED: bool>(rho: &[u8; 32]) -> [i16; K * K * N] {
+    let mut r = [0; _];
+
+    // We have K * K polynomials to generate.  In this case, K := 3, so 9.
+    // We have a by-4 keccak, so we can attack the problem in two
+    // sets of four, followed by one straggler.
+
+    let mut work_iter = SAMPLE_POLY_WORK.chunks_exact(4);
+
+    for c4 in work_iter.by_ref() {
+        let inputs = match TRANSPOSED {
+            false => &[
+                &[c4[0].1, c4[0].0],
+                &[c4[1].1, c4[1].0],
+                &[c4[2].1, c4[2].0],
+                &[c4[3].1, c4[3].0],
+            ],
+            true => &[
+                &[c4[0].0, c4[0].1],
+                &[c4[1].0, c4[1].1],
+                &[c4[2].0, c4[2].1],
+                &[c4[3].0, c4[3].1],
+            ],
+        };
+
+        _sample_poly_ntt_quad(
+            rho,
+            inputs,
+            (&mut r[c4[0].2..c4[3].2 + N]).try_into().unwrap(),
+        );
+    }
+
+    for (i, j, offs) in work_iter.remainder() {
+        let input = match TRANSPOSED {
+            false => &[*j, *i],
+            true => &[*i, *j],
+        };
+        Shake128ForMlKem::new(&[rho, input])
+            .sample_into((&mut r[*offs..*offs + N]).try_into().unwrap());
+    }
+
+    r
+}
+
+fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; N * 4]) {
+    let mut buf = [0; 40];
+    buf[..32].copy_from_slice(rho);
+    buf[34] = sha3::SHAKE_PAD_BYTE;
+
+    let mut buf0 = buf;
+    buf0[32..34].clone_from_slice(inputs[0]);
+    let mut buf1 = buf;
+    buf1[32..34].clone_from_slice(inputs[1]);
+    let mut buf2 = buf;
+    buf2[32..34].clone_from_slice(inputs[2]);
+    let mut buf3 = buf;
+    buf3[32..34].clone_from_slice(inputs[3]);
+
+    let sponge_4x = sha3::SqueezingSponge4xShake128::new(&[&buf0, &buf1, &buf2, &buf3]);
+    let (output0, outputs) = outputs.split_at_mut(N);
+    let (output1, outputs) = outputs.split_at_mut(N);
+    let (output2, output3) = outputs.split_at_mut(N);
+
+    let mut samples = [[0; sha3::SHAKE_128_R_BYTES * 3]; 4];
+    let [tsponge0, tsponge1, tsponge2, tsponge3] = sponge_4x.squeeze(&mut samples);
+
+    let tail0 = Shake128ForMlKem::sample(&samples[0], output0.try_into().unwrap());
+    let tail1 = Shake128ForMlKem::sample(&samples[1], output1.try_into().unwrap());
+    let tail2 = Shake128ForMlKem::sample(&samples[2], output2.try_into().unwrap());
+    let tail3 = Shake128ForMlKem::sample(&samples[3], output3.try_into().unwrap());
+
+    if !tail0.is_empty() {
+        Shake128ForMlKem {
+            sponge: tsponge0.restitute(),
+        }
+        .tail_case(tail0);
+    }
+
+    if !tail1.is_empty() {
+        Shake128ForMlKem {
+            sponge: tsponge1.restitute(),
+        }
+        .tail_case(tail1);
+    }
+
+    if !tail2.is_empty() {
+        Shake128ForMlKem {
+            sponge: tsponge2.restitute(),
+        }
+        .tail_case(tail2);
+    }
+
+    if !tail3.is_empty() {
+        Shake128ForMlKem {
+            sponge: tsponge3.restitute(),
+        }
+        .tail_case(tail3);
+    }
+}
+
+/// SHAKE128, but oriented at use in ML-KEM's `SampleNTT()`
+struct Shake128ForMlKem {
+    sponge: sha3::Shake128SqueezingSponge,
+}
+
+impl Shake128ForMlKem {
+    fn new(message: &[&[u8]]) -> Self {
+        Self {
+            sponge: sha3::Shake128Sponge::new_for_message(message),
+        }
+    }
+
+    /// Extract 256 coefficients that are < Q by rejection sampling.
+    ///
+    /// Refer to FIPS-203 `SampleNTT()`.  This function is the inner rejection loop.
+    fn sample_into(mut self, output: &mut [i16; 256]) {
+        // First, we squeeze three blocks.  Each block contributes up to 112 coefficients,
+        // so we get 336 candidate coefficients.
+        let mut initial_bytes = [0; sha3::SHAKE_128_R_BYTES * 3];
+        self.sponge.squeeze(&mut initial_bytes);
+
+        let tail = Self::sample(&initial_bytes, output);
+
+        // If we were unlucky, 336 candidate coeffients weren't enough.  That
+        // happens with low but not negligible probability (1 in ~120).
+        if !tail.is_empty() {
+            self.tail_case(tail);
+        }
+    }
+
+    /// Sample into `output` using the bytes `samples`
+    ///
+    /// Returns the _unwritten_ items in output.  Call `tail_case()` with this value if
+    /// non-empty.
+    #[must_use]
+    fn sample<'a>(
+        samples: &'_ [u8; sha3::SHAKE_128_R_BYTES * 3],
+        output: &'a mut [i16; 256],
+    ) -> &'a mut [i16] {
+        let used = low::mlkem_rej_uniform_vartime(output, samples) as usize;
+        output.split_at_mut(used).1
+    }
+
+    fn tail_case(self, output: &mut [i16]) {
+        let tail_iterator = Shake128TwelveBitIterator::new(self.sponge).filter(|f| *f < Q);
+
+        for (out, coeff) in output.iter_mut().zip(tail_iterator) {
+            *out = coeff;
+        }
+    }
+}
+
+/// Iterates over 12-bit samples drawn from `sponge`.
+struct Shake128TwelveBitIterator {
+    sponge: sha3::Shake128SqueezingSponge,
+    samples: [i16; Self::SAMPLE_COUNT],
+    used: usize,
+}
+
+impl Shake128TwelveBitIterator {
+    fn new(sponge: sha3::Shake128SqueezingSponge) -> Self {
+        Self {
+            sponge,
+            samples: [0; Self::SAMPLE_COUNT],
+            used: Self::SAMPLE_COUNT,
+        }
+    }
+
+    /// Each three bytes of SHAKE output yields two coefficients.
+    const SAMPLE_COUNT: usize = sha3::SHAKE_128_R_BYTES / 3 * 2;
+}
+
+impl Iterator for Shake128TwelveBitIterator {
+    type Item = i16;
+
+    #[cold]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.used == self.samples.len() {
+            let mut bytes = [0u8; sha3::SHAKE_128_R_BYTES];
+            self.sponge.squeeze(&mut bytes);
+
+            for (buf, d) in bytes.chunks_exact(3).zip(self.samples.chunks_exact_mut(2)) {
+                d[0] = (u16::from_le_bytes([buf[0], buf[1]]) & 0xfff) as i16;
+                d[1] = (u16::from_le_bytes([buf[1], buf[2]]) >> 4) as i16;
+            }
+            self.used = 0;
+        }
+
+        let item = self.samples[self.used];
+        self.used += 1;
+        Some(item)
+    }
+}
+
+/// Values for i and j (pre-transpose) plus start offset of N coefficients within
+/// a K * K * N matrix.
+const SAMPLE_POLY_WORK: &[(u8, u8, usize)] = &[
+    (0, 0, 0), //
+    (0, 1, N),
+    (0, 2, N * 2),
+    (1, 0, K * N),
+    (1, 1, N + K * N),
+    (1, 2, N * 2 + K * N),
+    (2, 0, K * N * 2),
+    (2, 1, N + K * N * 2),
+    (2, 2, N * 2 + K * N * 2),
+];

--- a/graviola/src/mid/mlkem768/sample_ntt.rs
+++ b/graviola/src/mid/mlkem768/sample_ntt.rs
@@ -64,44 +64,22 @@ fn _sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16
 
     for (inputs, outputs) in inputs.chunks_exact(4).zip(outputs.chunks_exact_mut(N * 4)) {
         let sponge_4x = sha3::SqueezingSponge4xShake128::new(&inputs.try_into().unwrap());
-        let (output0, outputs) = outputs.split_at_mut(N);
-        let (output1, outputs) = outputs.split_at_mut(N);
-        let (output2, output3) = outputs.split_at_mut(N);
 
         let mut samples = [[0; sha3::SHAKE_128_R_BYTES * 3]; 4];
-        let [tsponge0, tsponge1, tsponge2, tsponge3] = sponge_4x.squeeze(&mut samples);
+        let tail_sponges = sponge_4x.squeeze(&mut samples);
 
-        let tail0 = Shake128ForMlKem::sample(&samples[0], output0.try_into().unwrap());
-        let tail1 = Shake128ForMlKem::sample(&samples[1], output1.try_into().unwrap());
-        let tail2 = Shake128ForMlKem::sample(&samples[2], output2.try_into().unwrap());
-        let tail3 = Shake128ForMlKem::sample(&samples[3], output3.try_into().unwrap());
-
-        if !tail0.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge0.restitute(),
+        for ((output, samples), tail_sponge) in outputs
+            .chunks_exact_mut(N)
+            .zip(samples.iter())
+            .zip(tail_sponges)
+        {
+            let tail = Shake128ForMlKem::sample(samples, output.try_into().unwrap());
+            if !tail.is_empty() {
+                Shake128ForMlKem {
+                    sponge: tail_sponge.restitute(),
+                }
+                .tail_case(tail);
             }
-            .tail_case(tail0);
-        }
-
-        if !tail1.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge1.restitute(),
-            }
-            .tail_case(tail1);
-        }
-
-        if !tail2.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge2.restitute(),
-            }
-            .tail_case(tail2);
-        }
-
-        if !tail3.is_empty() {
-            Shake128ForMlKem {
-                sponge: tsponge3.restitute(),
-            }
-            .tail_case(tail3);
         }
     }
 }

--- a/graviola/src/mid/mlkem768/sample_ntt.rs
+++ b/graviola/src/mid/mlkem768/sample_ntt.rs
@@ -54,17 +54,16 @@ fn _sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16
     buf[..32].copy_from_slice(rho);
     buf[34] = sha3::SHAKE_PAD_BYTE;
 
-    for (inputs, outputs) in inputs.chunks_exact(4).zip(outputs.chunks_exact_mut(N * 4)) {
-        let mut buf0 = buf;
-        buf0[32..34].clone_from_slice(&inputs[0]);
-        let mut buf1 = buf;
-        buf1[32..34].clone_from_slice(&inputs[1]);
-        let mut buf2 = buf;
-        buf2[32..34].clone_from_slice(&inputs[2]);
-        let mut buf3 = buf;
-        buf3[32..34].clone_from_slice(&inputs[3]);
+    // Expand the indices `inputs` into the prefix of SHAKE inputs, by prepending `rho` and
+    // appending `SHAKE_PAD_BYTE`.
+    let inputs = inputs.map(|ij| {
+        let mut buf_ij = buf;
+        buf_ij[32..34].clone_from_slice(&ij);
+        buf_ij
+    });
 
-        let sponge_4x = sha3::SqueezingSponge4xShake128::new(&[&buf0, &buf1, &buf2, &buf3]);
+    for (inputs, outputs) in inputs.chunks_exact(4).zip(outputs.chunks_exact_mut(N * 4)) {
+        let sponge_4x = sha3::SqueezingSponge4xShake128::new(&inputs.try_into().unwrap());
         let (output0, outputs) = outputs.split_at_mut(N);
         let (output1, outputs) = outputs.split_at_mut(N);
         let (output2, output3) = outputs.split_at_mut(N);

--- a/graviola/src/mid/mlkem768/sample_ntt.rs
+++ b/graviola/src/mid/mlkem768/sample_ntt.rs
@@ -15,99 +15,95 @@ fn _sample_ntt<const TRANSPOSED: bool>(rho: &[u8; 32]) -> [i16; K * K * N] {
     let mut r = [0; _];
 
     // We have K * K polynomials to generate.  In this case, K := 3, so 9.
-    // We have a by-4 keccak, so we can attack the problem in two
-    // sets of four, followed by one straggler.
+    // We attack this as one block of 8, followed by a stragger.
 
-    let mut work_iter = SAMPLE_POLY_WORK.chunks_exact(4);
+    let (output_8, output_tail) = r.split_at_mut(N * 8);
 
-    for c4 in work_iter.by_ref() {
-        let inputs = match TRANSPOSED {
-            false => &[
-                &[c4[0].1, c4[0].0],
-                &[c4[1].1, c4[1].0],
-                &[c4[2].1, c4[2].0],
-                &[c4[3].1, c4[3].0],
-            ],
-            true => &[
-                &[c4[0].0, c4[0].1],
-                &[c4[1].0, c4[1].1],
-                &[c4[2].0, c4[2].1],
-                &[c4[3].0, c4[3].1],
-            ],
-        };
+    let inputs = match TRANSPOSED {
+        false => &[
+            [0, 0],
+            [1, 0],
+            [2, 0],
+            [0, 1],
+            [1, 1],
+            [2, 1],
+            [0, 2],
+            [1, 2],
+        ],
+        true => &[
+            [0, 0],
+            [0, 1],
+            [0, 2],
+            [1, 0],
+            [1, 1],
+            [1, 2],
+            [2, 0],
+            [2, 1],
+        ],
+    };
 
-        _sample_poly_ntt_quad(
-            rho,
-            inputs,
-            (&mut r[c4[0].2..c4[3].2 + N]).try_into().unwrap(),
-        );
-    }
+    _sample_poly_ntt_8x(rho, inputs, output_8.try_into().unwrap());
 
-    for (i, j, offs) in work_iter.remainder() {
-        let input = match TRANSPOSED {
-            false => &[*j, *i],
-            true => &[*i, *j],
-        };
-        Shake128ForMlKem::new(&[rho, input])
-            .sample_into((&mut r[*offs..*offs + N]).try_into().unwrap());
-    }
+    Shake128ForMlKem::new(&[rho, &[2, 2]]).sample_into(output_tail.try_into().unwrap());
 
     r
 }
 
-fn _sample_poly_ntt_quad(rho: &[u8; 32], inputs: &[&[u8; 2]; 4], outputs: &mut [i16; N * 4]) {
+fn _sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16; N * 8]) {
     let mut buf = [0; 40];
     buf[..32].copy_from_slice(rho);
     buf[34] = sha3::SHAKE_PAD_BYTE;
 
-    let mut buf0 = buf;
-    buf0[32..34].clone_from_slice(inputs[0]);
-    let mut buf1 = buf;
-    buf1[32..34].clone_from_slice(inputs[1]);
-    let mut buf2 = buf;
-    buf2[32..34].clone_from_slice(inputs[2]);
-    let mut buf3 = buf;
-    buf3[32..34].clone_from_slice(inputs[3]);
+    for (inputs, outputs) in inputs.chunks_exact(4).zip(outputs.chunks_exact_mut(N * 4)) {
+        let mut buf0 = buf;
+        buf0[32..34].clone_from_slice(&inputs[0]);
+        let mut buf1 = buf;
+        buf1[32..34].clone_from_slice(&inputs[1]);
+        let mut buf2 = buf;
+        buf2[32..34].clone_from_slice(&inputs[2]);
+        let mut buf3 = buf;
+        buf3[32..34].clone_from_slice(&inputs[3]);
 
-    let sponge_4x = sha3::SqueezingSponge4xShake128::new(&[&buf0, &buf1, &buf2, &buf3]);
-    let (output0, outputs) = outputs.split_at_mut(N);
-    let (output1, outputs) = outputs.split_at_mut(N);
-    let (output2, output3) = outputs.split_at_mut(N);
+        let sponge_4x = sha3::SqueezingSponge4xShake128::new(&[&buf0, &buf1, &buf2, &buf3]);
+        let (output0, outputs) = outputs.split_at_mut(N);
+        let (output1, outputs) = outputs.split_at_mut(N);
+        let (output2, output3) = outputs.split_at_mut(N);
 
-    let mut samples = [[0; sha3::SHAKE_128_R_BYTES * 3]; 4];
-    let [tsponge0, tsponge1, tsponge2, tsponge3] = sponge_4x.squeeze(&mut samples);
+        let mut samples = [[0; sha3::SHAKE_128_R_BYTES * 3]; 4];
+        let [tsponge0, tsponge1, tsponge2, tsponge3] = sponge_4x.squeeze(&mut samples);
 
-    let tail0 = Shake128ForMlKem::sample(&samples[0], output0.try_into().unwrap());
-    let tail1 = Shake128ForMlKem::sample(&samples[1], output1.try_into().unwrap());
-    let tail2 = Shake128ForMlKem::sample(&samples[2], output2.try_into().unwrap());
-    let tail3 = Shake128ForMlKem::sample(&samples[3], output3.try_into().unwrap());
+        let tail0 = Shake128ForMlKem::sample(&samples[0], output0.try_into().unwrap());
+        let tail1 = Shake128ForMlKem::sample(&samples[1], output1.try_into().unwrap());
+        let tail2 = Shake128ForMlKem::sample(&samples[2], output2.try_into().unwrap());
+        let tail3 = Shake128ForMlKem::sample(&samples[3], output3.try_into().unwrap());
 
-    if !tail0.is_empty() {
-        Shake128ForMlKem {
-            sponge: tsponge0.restitute(),
+        if !tail0.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge0.restitute(),
+            }
+            .tail_case(tail0);
         }
-        .tail_case(tail0);
-    }
 
-    if !tail1.is_empty() {
-        Shake128ForMlKem {
-            sponge: tsponge1.restitute(),
+        if !tail1.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge1.restitute(),
+            }
+            .tail_case(tail1);
         }
-        .tail_case(tail1);
-    }
 
-    if !tail2.is_empty() {
-        Shake128ForMlKem {
-            sponge: tsponge2.restitute(),
+        if !tail2.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge2.restitute(),
+            }
+            .tail_case(tail2);
         }
-        .tail_case(tail2);
-    }
 
-    if !tail3.is_empty() {
-        Shake128ForMlKem {
-            sponge: tsponge3.restitute(),
+        if !tail3.is_empty() {
+            Shake128ForMlKem {
+                sponge: tsponge3.restitute(),
+            }
+            .tail_case(tail3);
         }
-        .tail_case(tail3);
     }
 }
 
@@ -204,17 +200,3 @@ impl Iterator for Shake128TwelveBitIterator {
         Some(item)
     }
 }
-
-/// Values for i and j (pre-transpose) plus start offset of N coefficients within
-/// a K * K * N matrix.
-const SAMPLE_POLY_WORK: &[(u8, u8, usize)] = &[
-    (0, 0, 0), //
-    (0, 1, N),
-    (0, 2, N * 2),
-    (1, 0, K * N),
-    (1, 1, N + K * N),
-    (1, 2, N * 2 + K * N),
-    (2, 0, K * N * 2),
-    (2, 1, N + K * N * 2),
-    (2, 2, N * 2 + K * N * 2),
-];

--- a/graviola/src/mid/mlkem768/sample_ntt.rs
+++ b/graviola/src/mid/mlkem768/sample_ntt.rs
@@ -1,7 +1,11 @@
 // Written for Graviola by Joe Birr-Pixton, 2026.
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
 
-use crate::{low, mid::sha3};
+use super::{K, N, Q};
+use crate::{
+    low,
+    mid::sha3::{self, SqueezingSpongeObligation},
+};
 
 pub(super) fn sample_ntt(rho: &[u8; 32]) -> [i16; K * K * N] {
     _sample_ntt::<false>(rho)
@@ -42,14 +46,14 @@ fn _sample_ntt<const TRANSPOSED: bool>(rho: &[u8; 32]) -> [i16; K * K * N] {
         ],
     };
 
-    _sample_poly_ntt_8x(rho, inputs, output_8.try_into().unwrap());
+    sample_poly_ntt_8x(rho, inputs, output_8.try_into().unwrap());
 
     Shake128ForMlKem::new(&[rho, &[2, 2]]).sample_into(output_tail.try_into().unwrap());
 
     r
 }
 
-fn _sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16; N * 8]) {
+fn sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16; N * 8]) {
     let mut buf = [0; 40];
     buf[..32].copy_from_slice(rho);
     buf[34] = sha3::SHAKE_PAD_BYTE;
@@ -62,6 +66,10 @@ fn _sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16
         buf_ij
     });
 
+    low::mlkem768_sample_poly_ntt_8x(&inputs, outputs, _sample_poly_ntt_8x, _sample_poly_ntt_tail)
+}
+
+fn _sample_poly_ntt_8x(inputs: &[[u8; 40]; 8], outputs: &mut [i16; N * 8]) {
     for (inputs, outputs) in inputs.chunks_exact(4).zip(outputs.chunks_exact_mut(N * 4)) {
         let sponge_4x = sha3::SqueezingSponge4xShake128::new(&inputs.try_into().unwrap());
 
@@ -82,6 +90,13 @@ fn _sample_poly_ntt_8x(rho: &[u8; 32], inputs: &[[u8; 2]; 8], outputs: &mut [i16
             }
         }
     }
+}
+
+fn _sample_poly_ntt_tail(tail_sponge: &mut [u64; 25], tail: &mut [i16]) {
+    Shake128ForMlKem {
+        sponge: SqueezingSpongeObligation(*tail_sponge).restitute(),
+    }
+    .tail_case(tail);
 }
 
 /// SHAKE128, but oriented at use in ML-KEM's `SampleNTT()`

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -361,7 +361,7 @@ impl SqueezingSponge4xShake128 {
 }
 
 /// A [`SqueezingSponge`] to which we owe a keccak-f application prior to further use.
-pub(crate) struct SqueezingSpongeObligation<const R: usize>([u64; 25]);
+pub(crate) struct SqueezingSpongeObligation<const R: usize>(pub(crate) [u64; 25]);
 
 impl<const R: usize> SqueezingSpongeObligation<R> {
     /// Pay back the debt by applying keccak-f and return the underlying [`SqueezingSponge`]

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -273,7 +273,7 @@ impl SqueezingSponge4xShake128 {
     ///
     /// Each item of `input` shall be 40 bytes in length, which matches ML-KEM's requirements
     /// of 34 bytes.  The 35th byte shall be `SHAKE_PAD_BYTE` and the remainder shall be zeroes.
-    pub(crate) fn new(inputs: &[&[u8; 40]; 4]) -> Self {
+    pub(crate) fn new(inputs: &[[u8; 40]; 4]) -> Self {
         debug_assert!(inputs.iter().all(|inp| inp[34] == SHAKE_PAD_BYTE));
 
         // This is gnarly, for the benefit of avoiding a SHAKE_128_R_BYTES-byte buffer which is
@@ -603,7 +603,7 @@ mod tests {
         // batched: three rate-blocks up front, then continue via the obligation.
         let mut batched = [[0u8; SHAKE_128_R_BYTES * 3]; 4];
         let obligations =
-            SqueezingSponge4xShake128::new(&[&inputs[0], &inputs[1], &inputs[2], &inputs[3]])
+            SqueezingSponge4xShake128::new(&[inputs[0], inputs[1], inputs[2], inputs[3]])
                 .squeeze(&mut batched);
 
         const TAIL: usize = SHAKE_128_R_BYTES * 2;


### PR DESCRIPTION
This introduces a AVX512 by-8 keccak-f, and then also uses AVX512 to do rejection sampling in `SampleNTT`; integrated together to avoid excess vector-to-memory-to-vector transitions.

```
mlkem768-combined/graviola
                        time:   [27.103 µs 27.214 µs 27.337 µs]
                        thrpt:  [36.581 Kelem/s 36.746 Kelem/s 36.896 Kelem/s]
                 change:
                        time:   [−10.808% −9.2145% −7.5153%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1260% +10.150% +12.118%]
                        Performance has improved.
```