### PR TITLE
perf: avoid a memmove in SqueezingSponge4xShake128::squeeze

### DIFF
--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -330,7 +330,8 @@ impl SqueezingSponge4xShake128 {
             span: Range<usize>,
         ) {
             for j in 0..4 {
-                for (i, ch) in output[j][span.clone()].chunks_mut(8).enumerate() {
+                debug_assert!(span.len().is_multiple_of(8));
+                for (i, ch) in output[j][span.clone()].chunks_exact_mut(8).enumerate() {
                     ch.copy_from_slice(&states[j][i].to_le_bytes());
                 }
             }


### PR DESCRIPTION
Profiling on macos/aarch64 showed that the inner `squeeze_rate` function was doing a `memmove` call for each 8-byte chunk. Switching from `chunks_mut` to `chunks_exact_mut` results in a simple 64-bit load and store in place of the `memmove` call.