### PR TITLE
Fix new Clippy warnings

### DIFF
--- a/graviola/src/low/aarch64/aes_gcm.rs
+++ b/graviola/src/low/aarch64/aes_gcm.rs
@@ -48,9 +48,9 @@ fn _cipher<const ENC: bool>(
     let inc = vsetq_lane_u8(1, vdupq_n_u8(0), 15);
     let inc = vreinterpretq_u32_u8(vrev32q_u8(inc));
 
-    let mut by8 = cipher_inout.chunks_exact_mut(128);
+    let (by8, remainder) = cipher_inout.as_chunks_mut::<128>();
 
-    for cipher8 in by8.by_ref() {
+    for cipher8 in by8 {
         cpu::prefetch_rw(cipher8.as_ptr());
         counter = vaddq_u32(counter, inc);
         let b0 = vrev32q_u8(vreinterpretq_u8_u32(counter));
@@ -133,9 +133,9 @@ fn _cipher<const ENC: bool>(
         }
     }
 
-    let mut singles = by8.into_remainder().chunks_exact_mut(16);
+    let (singles, remainder) = remainder.as_chunks_mut::<16>();
 
-    for cipher in singles.by_ref() {
+    for cipher in singles {
         // SAFETY: cipher is 16 bytes long, via `chunks_exact_mut`.
         let input_block = unsafe { vld1q_u8(cipher.as_ptr().add(0).cast()) };
         if !ENC {
@@ -164,7 +164,7 @@ fn _cipher<const ENC: bool>(
     }
 
     {
-        let cipher_inout = singles.into_remainder();
+        let cipher_inout = remainder;
         if !cipher_inout.is_empty() {
             if !ENC {
                 ghash.add(cipher_inout);

--- a/graviola/src/low/aarch64/bignum_point_select_p256.rs
+++ b/graviola/src/low/aarch64/bignum_point_select_p256.rs
@@ -35,7 +35,8 @@ fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
     let mut index = vdupq_n_u32(1);
     let ones = index;
 
-    for point in table.chunks_exact(8) {
+    let (chunks, _) = table.as_chunks::<8>();
+    for point in chunks {
         // SAFETY: `point` is 8 64-bit words, via `chunks_exact`
         let (row0, row1, row2, row3) = unsafe {
             (
@@ -83,7 +84,8 @@ fn _select_jac_p256(z: &mut [u64; 12], table: &[u64], index: u8) {
     let mut index = vdupq_n_u32(1);
     let ones = index;
 
-    for point in table.chunks_exact(12) {
+    let (chunks, _) = table.as_chunks::<12>();
+    for point in chunks {
         // SAFETY: `point` is 12 64-bit words, via `chunks_exact`
         let (row0, row1, row2, row3, row4, row5) = unsafe {
             (

--- a/graviola/src/low/aarch64/bignum_point_select_p384.rs
+++ b/graviola/src/low/aarch64/bignum_point_select_p384.rs
@@ -29,7 +29,8 @@ fn _select_jac_p384(z: &mut [u64; 18], table: &[u64], index: u8) {
     let mut index = vdupq_n_u32(1);
     let ones = index;
 
-    for point in table.chunks_exact(18) {
+    let (chunks, _) = table.as_chunks::<18>();
+    for point in chunks {
         // SAFETY: `point` has 18 words and is readable, via `chunks_exact`
         let (row0, row1, row2, row3, row4, row5, row6, row7, row8) = unsafe {
             (

--- a/graviola/src/low/aarch64/ghash.rs
+++ b/graviola/src/low/aarch64/ghash.rs
@@ -70,9 +70,9 @@ impl<'a> Ghash<'a> {
     ///
     /// `bytes` is zero-padded, if required.
     pub(crate) fn add(&mut self, bytes: &[u8]) {
-        let mut by8_blocks = bytes.chunks_exact(128);
+        let (by8_blocks, remainder) = bytes.as_chunks::<128>();
 
-        for chunk8 in by8_blocks.by_ref() {
+        for chunk8 in by8_blocks {
             self.eight_blocks(
                 u128::from_be_bytes(chunk8[0..16].try_into().unwrap()),
                 u128::from_be_bytes(chunk8[16..32].try_into().unwrap()),
@@ -85,14 +85,14 @@ impl<'a> Ghash<'a> {
             );
         }
 
-        let mut whole_blocks = by8_blocks.remainder().chunks_exact(16);
+        let (whole_blocks, remainder) = remainder.as_chunks::<16>();
 
-        for chunk in whole_blocks.by_ref() {
-            let u = u128::from_be_bytes(chunk.try_into().unwrap());
+        for chunk in whole_blocks {
+            let u = u128::from_be_bytes(*chunk);
             self.one_block(u);
         }
 
-        let bytes = whole_blocks.remainder();
+        let bytes = remainder;
         if !bytes.is_empty() {
             let mut block = [0u8; 16];
             block[..bytes.len()].copy_from_slice(bytes);

--- a/graviola/src/low/aarch64/sha256.rs
+++ b/graviola/src/low/aarch64/sha256.rs
@@ -63,7 +63,8 @@ fn sha256(state: &mut [u32; 8], blocks: &[u8]) {
     let k14 = k!(14);
     let k15 = k!(15);
 
-    for block in blocks.chunks_exact(64) {
+    let (chunks, _) = blocks.as_chunks::<64>();
+    for block in chunks {
         let state0_prev = state0;
         let state1_prev = state1;
 

--- a/graviola/src/low/generic/ghash.rs
+++ b/graviola/src/low/generic/ghash.rs
@@ -27,14 +27,14 @@ impl<'a> Ghash<'a> {
     ///
     /// `bytes` is zero-padded, if required.
     pub(crate) fn add(&mut self, bytes: &[u8]) {
-        let mut whole_blocks = bytes.chunks_exact(16);
+        let (whole_blocks, remainder) = bytes.as_chunks::<16>();
 
-        for chunk in whole_blocks.by_ref() {
-            let u = u128::from_be_bytes(chunk.try_into().unwrap());
+        for chunk in whole_blocks {
+            let u = u128::from_be_bytes(*chunk);
             self.one_block(u);
         }
 
-        let bytes = whole_blocks.remainder();
+        let bytes = remainder;
         if !bytes.is_empty() {
             let mut block = [0u8; 16];
             block[..bytes.len()].copy_from_slice(bytes);

--- a/graviola/src/low/generic/mlkem.rs
+++ b/graviola/src/low/generic/mlkem.rs
@@ -8,7 +8,9 @@
 /// This accepts an array of 384 bytes and unpacks them into 256 16-bit numbers
 /// in the range 0 <= a[i] < 2^12 (typically they will be < 3329, the ML-KEM prime).
 pub(crate) fn mlkem_frombytes(r: &mut [i16; 256], a: &[u8; 384]) {
-    for (r, a) in r.chunks_exact_mut(2).zip(a.chunks_exact(3)) {
+    let (r_chunks, _) = r.as_chunks_mut::<2>();
+    let (a_chunks, _) = a.as_chunks::<3>();
+    for (r, a) in r_chunks.iter_mut().zip(a_chunks.iter()) {
         r[0] = (a[0] as i16) | (((a[1] & 0x0f) as i16) << 8);
         r[1] = ((a[1] >> 4) as i16) | ((a[2] as i16) << 4);
     }

--- a/graviola/src/low/generic/poly1305.rs
+++ b/graviola/src/low/generic/poly1305.rs
@@ -55,12 +55,12 @@ impl Poly1305 {
             self.process_whole_block(&block);
         }
 
-        let mut full_blocks = bytes.chunks_exact(16);
-        for block in full_blocks.by_ref() {
-            self.process_whole_block(block.try_into().unwrap());
+        let (full_blocks, remainder) = bytes.as_chunks::<16>();
+        for block in full_blocks {
+            self.process_whole_block(block);
         }
 
-        self.bw.add_trailing(full_blocks.remainder());
+        self.bw.add_trailing(remainder);
     }
 
     pub(crate) fn finish(mut self) -> [u8; 16] {

--- a/graviola/src/low/generic/sha256.rs
+++ b/graviola/src/low/generic/sha256.rs
@@ -99,7 +99,8 @@ fn sha256_compress_block(state: &mut [u32; 8], block: &[u8]) {
 pub(crate) fn sha256_compress_blocks(state: &mut [u32; 8], blocks: &[u8]) {
     debug_assert!(blocks.len().is_multiple_of(64));
 
-    for block in blocks.chunks_exact(64) {
+    let (chunks, _) = blocks.as_chunks::<64>();
+    for block in chunks {
         sha256_compress_block(state, block);
     }
 }

--- a/graviola/src/low/generic/sha512.rs
+++ b/graviola/src/low/generic/sha512.rs
@@ -99,7 +99,8 @@ fn sha512_compress_block(state: &mut [u64; 8], block: &[u8]) {
 pub(crate) fn sha512_compress_blocks(state: &mut [u64; 8], blocks: &[u8]) {
     debug_assert!(blocks.len().is_multiple_of(128));
 
-    for block in blocks.chunks_exact(128) {
+    let (chunks, _) = blocks.as_chunks::<128>();
+    for block in chunks {
         sha512_compress_block(state, block);
     }
 }

--- a/graviola/src/low/posint.rs
+++ b/graviola/src/low/posint.rs
@@ -98,7 +98,8 @@ impl<const N: usize> PosInt<N> {
         let required_bytes = self.used * 8;
         let out = out.get_mut(..required_bytes).ok_or(Error::OutOfRange)?;
 
-        for (chunk, word) in out.chunks_exact_mut(8).rev().zip(self.as_words().iter()) {
+        let (chunks, _) = out.as_chunks_mut::<8>();
+        for (chunk, word) in chunks.iter_mut().rev().zip(self.as_words().iter()) {
             chunk.copy_from_slice(&word.to_be_bytes());
         }
 
@@ -117,7 +118,8 @@ impl<const N: usize> PosInt<N> {
         {
             let (_, val) = out.split_at_mut(1);
 
-            for (chunk, word) in val.chunks_exact_mut(8).rev().zip(self.as_words().iter()) {
+            let (chunks, _) = val.as_chunks_mut::<8>();
+            for (chunk, word) in chunks.iter_mut().rev().zip(self.as_words().iter()) {
                 chunk.copy_from_slice(&word.to_be_bytes());
             }
         }

--- a/graviola/src/low/x86_64/aes_gcm.rs
+++ b/graviola/src/low/x86_64/aes_gcm.rs
@@ -63,10 +63,10 @@ fn _cipher<const ENC: bool>(
     let (rk_first, rks, rk_last) = key.round_keys();
 
     let mut counter = Counter::new(initial_counter);
-    let mut by8_iter = cipher_inout.chunks_exact_mut(128);
+    let (by8_iter, remainder) = cipher_inout.as_chunks_mut::<128>();
     let avx_ghash_table = ghash.table.avx();
 
-    for blocks in by8_iter.by_ref() {
+    for blocks in by8_iter {
         // prefetch to avoid any stall later
         super::cpu::prefetch(blocks, 64);
 
@@ -131,7 +131,7 @@ fn _cipher<const ENC: bool>(
         let c7 = _mm_xor_si128(c7, p7);
         let c8 = _mm_xor_si128(c8, p8);
 
-        // SAFETY: `blocks` is 128 bytes and writable, due to `chunks_exact_mut`
+        // SAFETY: `blocks` is 128 bytes and writable, due to `as_chunks_mut`
         unsafe {
             _mm_storeu_si128(blocks.as_mut_ptr().add(0).cast(), c1);
             _mm_storeu_si128(blocks.as_mut_ptr().add(16).cast(), c2);
@@ -162,15 +162,15 @@ fn _cipher<const ENC: bool>(
         ghash.current = ghash::_mul8(avx_ghash_table, a1, a2, a3, a4, a5, a6, a7, a8);
     }
 
-    let cipher_inout = by8_iter.into_remainder();
+    let cipher_inout = remainder;
 
     if !ENC {
         ghash.add(cipher_inout);
     }
 
     {
-        let mut blocks_iter = cipher_inout.chunks_exact_mut(16);
-        for block in blocks_iter.by_ref() {
+        let (blocks_iter, remainder) = cipher_inout.as_chunks_mut::<16>();
+        for block in blocks_iter {
             let c1 = counter.next();
 
             let mut c1 = _mm_xor_si128(c1, rk_first);
@@ -181,15 +181,15 @@ fn _cipher<const ENC: bool>(
 
             let c1 = _mm_aesenclast_si128(c1, rk_last);
 
-            // SAFETY: `block` is 16 bytes due to `chunks_exact_mut`
+            // SAFETY: `block` is 16 bytes due to `as_chunks_mut`
             let p1 = unsafe { _mm_loadu_si128(block.as_ptr().cast()) };
             let c1 = _mm_xor_si128(c1, p1);
 
-            // SAFETY: `block` is 16 bytes and writable, due to `chunks_exact_mut`
+            // SAFETY: `block` is 16 bytes and writable, due to `as_chunks_mut`
             unsafe { _mm_storeu_si128(block.as_mut_ptr().cast(), c1) };
         }
 
-        let cipher_inout = blocks_iter.into_remainder();
+        let cipher_inout = remainder;
         if !cipher_inout.is_empty() {
             let mut block = [0u8; 16];
             let len = cipher_inout.len();
@@ -240,14 +240,14 @@ fn _cipher_avx512<const ENC: bool>(
     let (rk_first, rks, rk_last) = round_keys.split();
 
     let mut counter = Counter512::new(initial_counter);
-    let mut by16_iter = cipher_inout.chunks_exact_mut(AVX512_MINIMUM_CIPHER_LEN);
+    let (by16_iter, remainder) = cipher_inout.as_chunks_mut::<AVX512_MINIMUM_CIPHER_LEN>();
 
     let ghash_avx512 = match ghash.table {
         GhashTable::Avx512(ghash_avx512) => ghash_avx512,
         _ => panic!("unexpected ghash table variant"),
     };
 
-    for blocks in by16_iter.by_ref() {
+    for blocks in by16_iter {
         // prefetch to avoid any stall later
         super::cpu::prefetch(blocks, 256);
 
@@ -273,7 +273,7 @@ fn _cipher_avx512<const ENC: bool>(
         let c89ab = _mm512_aesenclast_epi128(c89ab, rk_last);
         let ccdef = _mm512_aesenclast_epi128(ccdef, rk_last);
 
-        // SAFETY: `blocks` is 256 bytes due to `chunks_exact_mut`
+        // SAFETY: `blocks` is 256 bytes due to `as_chunks_mut`
         let (p0123, p4567, p89ab, pcdef) = unsafe {
             (
                 _mm512_loadu_si512(blocks.as_ptr().add(0).cast()),
@@ -288,7 +288,7 @@ fn _cipher_avx512<const ENC: bool>(
         let c89ab = _mm512_xor_epi32(c89ab, p89ab);
         let ccdef = _mm512_xor_epi32(ccdef, pcdef);
 
-        // SAFETY: `blocks` is 256 bytes and writable due to `chunks_exact_mut`
+        // SAFETY: `blocks` is 256 bytes and writable due to `as_chunks_mut`
         unsafe {
             _mm512_storeu_si512(blocks.as_mut_ptr().add(0).cast(), c0123);
             _mm512_storeu_si512(blocks.as_mut_ptr().add(64).cast(), c4567);
@@ -313,7 +313,7 @@ fn _cipher_avx512<const ENC: bool>(
         ghash.current = ghash::_mul16(ghash_avx512, a0123, a4567, a89ab, acdef);
     }
 
-    let cipher_inout = by16_iter.into_remainder();
+    let cipher_inout = remainder;
     let mut counter = counter.into_128();
 
     if !ENC {
@@ -321,9 +321,9 @@ fn _cipher_avx512<const ENC: bool>(
     }
 
     {
-        let mut blocks_iter = cipher_inout.chunks_exact_mut(16);
+        let (blocks_iter, remainder) = cipher_inout.as_chunks_mut::<16>();
         let (rk_first, rks, rk_last) = key.round_keys();
-        for block in blocks_iter.by_ref() {
+        for block in blocks_iter {
             let c1 = counter.next();
 
             let mut c1 = _mm_xor_si128(c1, rk_first);
@@ -344,7 +344,7 @@ fn _cipher_avx512<const ENC: bool>(
             }
         }
 
-        let cipher_inout = blocks_iter.into_remainder();
+        let cipher_inout = remainder;
         if !cipher_inout.is_empty() {
             let mut block = [0u8; 16];
             let len = cipher_inout.len();

--- a/graviola/src/low/x86_64/bignum_copy_row_from_table_16_avx2.rs
+++ b/graviola/src/low/x86_64/bignum_copy_row_from_table_16_avx2.rs
@@ -34,7 +34,8 @@ fn _bignum_copy_row_from_table_16_avx2(z: &mut [u64], table: &[u64], index: u64)
     let ones = _mm_set1_epi64x(1);
     let ones = _mm256_setr_m128i(ones, ones);
 
-    for row in table.chunks_exact(16) {
+    let (rows, _) = table.as_chunks::<16>();
+    for row in rows {
         let mask = _mm256_cmpeq_epi64(index, desired_index);
         index = _mm256_add_epi64(index, ones);
 

--- a/graviola/src/low/x86_64/bignum_copy_row_from_table_8n_avx2.rs
+++ b/graviola/src/low/x86_64/bignum_copy_row_from_table_8n_avx2.rs
@@ -37,7 +37,8 @@ fn _bignum_copy_row_from_table_8n_avx2(z: &mut [u64], table: &[u64], width: u64,
         let mask = _mm256_cmpeq_epi64(index, desired_index);
         index = _mm256_add_epi64(index, ones);
 
-        for (i, zz) in z.chunks_exact_mut(8).enumerate() {
+        let (chunks, _) = z.as_chunks_mut::<8>();
+        for (i, zz) in chunks.iter_mut().enumerate() {
             // SAFETY: `row` is a multiple of 8 words in length
             let (row0, row1) = unsafe {
                 (

--- a/graviola/src/low/x86_64/bignum_point_select_p256.rs
+++ b/graviola/src/low/x86_64/bignum_point_select_p256.rs
@@ -37,8 +37,9 @@ fn _select_aff_p256(z: &mut [u64; 8], table: &[u64], index: u8) {
 
     let ones = index;
 
-    for point in table.chunks_exact(8) {
-        // SAFETY: `point` is 8 words due to `chunks_exact` and readable
+    let (chunks, _) = table.as_chunks::<8>();
+    for point in chunks {
+        // SAFETY: `point` is 8 words due to `as_chunks` and readable
         let (row0, row1) = unsafe {
             (
                 _mm256_loadu_si256(point.as_ptr().add(0).cast()),
@@ -79,8 +80,9 @@ fn _select_jac_p256(z: &mut [u64; 12], table: &[u64], index: u8) {
 
     let ones = index;
 
-    for point in table.chunks_exact(12) {
-        // SAFETY: `point` is 12 words due to `chunks_exact` and readable
+    let (chunks, _) = table.as_chunks::<12>();
+    for point in chunks {
+        // SAFETY: `point` is 12 words due to `as_chunks` and readable
         let (row0, row1, row2) = unsafe {
             (
                 _mm256_loadu_si256(point.as_ptr().add(0).cast()),

--- a/graviola/src/low/x86_64/bignum_point_select_p384.rs
+++ b/graviola/src/low/x86_64/bignum_point_select_p384.rs
@@ -29,8 +29,9 @@ fn _select_jac_p384(z: &mut [u64; 18], table: &[u64], index: u8) {
 
     let ones = index;
 
-    for point in table.chunks_exact(18) {
-        // SAFETY: `point` is 18 words due to `chunks_exact` and readable.
+    let (chunks, _) = table.as_chunks::<18>();
+    for point in chunks {
+        // SAFETY: `point` is 18 words due to `as_chunks` and readable.
         let (row0, row1, row2, row3) = unsafe {
             (
                 _mm256_loadu_si256(point.as_ptr().add(0).cast()),

--- a/graviola/src/low/x86_64/chacha20.rs
+++ b/graviola/src/low/x86_64/chacha20.rs
@@ -16,16 +16,16 @@ impl ChaCha20 {
     }
 
     pub(crate) fn cipher(&mut self, buffer: &mut [u8]) {
-        let mut by8 = buffer.chunks_exact_mut(512);
+        let (by8, remainder) = buffer.as_chunks_mut::<512>();
 
-        for block in by8.by_ref() {
+        for block in by8 {
             // SAFETY: this crate requires the `avx2` cpu feature
             unsafe {
                 core_8x(self.z07, &mut self.z8f, block);
             }
         }
 
-        for block in by8.into_remainder().chunks_mut(128) {
+        for block in remainder.chunks_mut(128) {
             // SAFETY: this crate requires the `avx2` cpu feature
             unsafe {
                 core_2x(self.z07, &mut self.z8f, block);

--- a/graviola/src/low/x86_64/ghash.rs
+++ b/graviola/src/low/x86_64/ghash.rs
@@ -81,9 +81,9 @@ impl GhashTableAvx {
     }
 
     fn add_wide<'a>(&self, bytes: &'a [u8], mut current: __m128i) -> (__m128i, &'a [u8]) {
-        let mut eight_blocks = bytes.chunks_exact(128);
+        let (eight_blocks, remainder) = bytes.as_chunks::<128>();
 
-        for chunk8 in eight_blocks.by_ref() {
+        for chunk8 in eight_blocks {
             let u1 = u128::from_be_bytes(chunk8[0..16].try_into().unwrap());
             let u2 = u128::from_be_bytes(chunk8[16..32].try_into().unwrap());
             let u3 = u128::from_be_bytes(chunk8[32..48].try_into().unwrap());
@@ -109,7 +109,7 @@ impl GhashTableAvx {
             }
         }
 
-        (current, eight_blocks.remainder())
+        (current, remainder)
     }
 }
 
@@ -152,8 +152,8 @@ impl GhashTableAvx512 {
     fn add_wide<'a>(&self, bytes: &'a [u8], mut current: __m128i) -> (__m128i, &'a [u8]) {
         let bswap_mask = _mm512_broadcast_i32x4(BYTESWAP);
 
-        let mut by_16_blocks = bytes.chunks_exact(256);
-        for chunk16 in by_16_blocks.by_ref() {
+        let (by_16_blocks, remainder) = bytes.as_chunks::<256>();
+        for chunk16 in by_16_blocks {
             // SAFETY: `chunk16` is 256 bytes and readable, via `chunks_exact`
             let (m0123, m4567, m89ab, mcdef) = unsafe {
                 (
@@ -175,7 +175,7 @@ impl GhashTableAvx512 {
             current = _mul16(self, m0123, m4567, m89ab, mcdef);
         }
 
-        (current, by_16_blocks.remainder())
+        (current, remainder)
     }
 }
 
@@ -202,14 +202,14 @@ impl<'a> Ghash<'a> {
             GhashTable::Avx512(avx512) => unsafe { avx512.add_wide(bytes, self.current) },
         };
 
-        let mut whole_blocks = bytes.chunks_exact(16);
+        let (whole_blocks, remainder) = bytes.as_chunks::<16>();
 
-        for chunk in whole_blocks.by_ref() {
-            let u = u128::from_be_bytes(chunk.try_into().unwrap());
+        for chunk in whole_blocks {
+            let u = u128::from_be_bytes(*chunk);
             self.one_block(u128_to_m128i(u));
         }
 
-        let bytes = whole_blocks.remainder();
+        let bytes = remainder;
         if !bytes.is_empty() {
             let mut block = [0u8; 16];
             block[..bytes.len()].copy_from_slice(bytes);

--- a/graviola/src/low/x86_64/sha256.rs
+++ b/graviola/src/low/x86_64/sha256.rs
@@ -82,7 +82,8 @@ fn sha256(state: &mut [u32; 8], blocks: &[u8]) {
     let k14 = k!(14);
     let k15 = k!(15);
 
-    for block in blocks.chunks_exact(64) {
+    let (chunks, _) = blocks.as_chunks::<64>();
+    for block in chunks {
         let state0_prev = state0;
         let state1_prev = state1;
 

--- a/graviola/src/low/x86_64/sha512.rs
+++ b/graviola/src/low/x86_64/sha512.rs
@@ -216,7 +216,8 @@ fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
     let mut f = _mm256_extract_epi64(save_efgh, 1) as u64;
     let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
     let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
-    for w_t in w.chunks_exact(8) {
+    let (chunks, _) = w.as_chunks::<8>();
+    for w_t in chunks {
         round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 0));
         round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 0));
         round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 0));
@@ -246,7 +247,8 @@ fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
     let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
     let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
 
-    for w_t in w.chunks_exact(8) {
+    let (chunks, _) = w.as_chunks::<8>();
+    for w_t in chunks {
         round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 1));
         round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 1));
         round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 1));
@@ -276,7 +278,8 @@ fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
     let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
     let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
 
-    for w_t in w.chunks_exact(8) {
+    let (chunks, _) = w.as_chunks::<8>();
+    for w_t in chunks {
         round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 2));
         round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 2));
         round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 2));
@@ -306,7 +309,8 @@ fn sha512_compress_4_blocks(state: &mut [u64; 8], block4: *const u64) {
     let mut g = _mm256_extract_epi64(save_efgh, 2) as u64;
     let mut h = _mm256_extract_epi64(save_efgh, 3) as u64;
 
-    for w_t in w.chunks_exact(8) {
+    let (chunks, _) = w.as_chunks::<8>();
+    for w_t in chunks {
         round!(a, b, c, d, e, f, g, h, _mm256_extract_epi64(w_t[0], 3));
         round!(h, a, b, c, d, e, f, g, _mm256_extract_epi64(w_t[1], 3));
         round!(g, h, a, b, c, d, e, f, _mm256_extract_epi64(w_t[2], 3));
@@ -466,15 +470,15 @@ pub(in crate::low) fn sha512_compress_blocks(
     blocks: &[u8],
     _token: super::cpu::HaveBmi2,
 ) {
-    let mut iter4 = blocks.chunks_exact(512);
-    for block4 in iter4.by_ref() {
+    let (iter4, remainder) = blocks.as_chunks::<512>();
+    for block4 in iter4 {
         // SAFETY: `_token` proves caller checked cpu features for `bmi2`;
         // `avx` and `avx2` required by crate.
         unsafe { sha512_compress_4_blocks(state, block4.as_ptr().cast()) };
     }
-    let blocks = iter4.remainder();
 
-    for block in blocks.chunks_exact(128) {
+    let (chunks, _) = remainder.as_chunks::<128>();
+    for block in chunks {
         // SAFETY: caller checks cpu features for `bmi2`; `avx` and `avx2` required by crate.
         unsafe { sha512_compress_block(state, block) }
     }

--- a/graviola/src/mid/mlkem768.rs
+++ b/graviola/src/mid/mlkem768.rs
@@ -424,9 +424,9 @@ impl Coeffs<{ K * K * N }, Ntt> {
         // We have a by-4 keccak, so we can attack the problem in two
         // sets of four, followed by one straggler.
 
-        let mut work_iter = SAMPLE_POLY_WORK.chunks_exact(4);
+        let (work_iter, remainder) = SAMPLE_POLY_WORK.as_chunks::<4>();
 
-        for c4 in work_iter.by_ref() {
+        for c4 in work_iter {
             let inputs = match TRANSPOSED {
                 false => &[
                     &[c4[0].1, c4[0].0],
@@ -449,7 +449,7 @@ impl Coeffs<{ K * K * N }, Ntt> {
             );
         }
 
-        for (i, j, offs) in work_iter.remainder() {
+        for (i, j, offs) in remainder {
             let input = match TRANSPOSED {
                 false => &[*j, *i],
                 true => &[*i, *j],
@@ -912,8 +912,10 @@ impl<const C: usize> Coeffs<C, Normal> {
 }
 
 fn sample_cbd2(buf: &[u8; 128], out: &mut [i16; 256]) {
-    for (in_bytes, out_coeffs) in buf.chunks_exact(4).zip(out.chunks_exact_mut(8)) {
-        let t = u32::from_le_bytes(in_bytes.try_into().unwrap());
+    let (buf_chunks, _) = buf.as_chunks::<4>();
+    let (out_chunks, _) = out.as_chunks_mut::<8>();
+    for (in_bytes, out_coeffs) in buf_chunks.iter().zip(out_chunks.iter_mut()) {
+        let t = u32::from_le_bytes(*in_bytes);
         let d = (t & 0x5555_5555) + ((t >> 1) & 0x5555_5555);
 
         for (j, coeff) in out_coeffs.iter_mut().enumerate() {
@@ -1005,7 +1007,11 @@ impl Iterator for Shake128TwelveBitIterator {
             let mut bytes = [0u8; sha3::SHAKE_128_R_BYTES];
             self.sponge.squeeze(&mut bytes);
 
-            for (buf, d) in bytes.chunks_exact(3).zip(self.samples.chunks_exact_mut(2)) {
+            let (chunks, _) = bytes.as_chunks::<3>();
+            for (buf, d) in chunks
+                .iter()
+                .zip(self.samples.as_chunks_mut::<2>().0.iter_mut())
+            {
                 d[0] = (u16::from_le_bytes([buf[0], buf[1]]) & 0xfff) as i16;
                 d[1] = (u16::from_le_bytes([buf[1], buf[2]]) >> 4) as i16;
             }

--- a/graviola/src/mid/p256.rs
+++ b/graviola/src/mid/p256.rs
@@ -413,7 +413,8 @@ impl AffineMontPoint {
         // now linearise, so table lookup can be type safe
         let mut t = [0; 192];
 
-        for (out, rr) in t.chunks_exact_mut(12).zip(r) {
+        let (chunks, _) = t.as_chunks_mut::<12>();
+        for (out, rr) in chunks.iter_mut().zip(r) {
             out.copy_from_slice(&rr.xyz);
         }
 

--- a/graviola/src/mid/p384.rs
+++ b/graviola/src/mid/p384.rs
@@ -360,7 +360,8 @@ impl AffineMontPoint {
 
         let mut t = [0; 288];
 
-        for (out, rr) in t.chunks_exact_mut(18).zip(r) {
+        let (chunks, _) = t.as_chunks_mut::<18>();
+        for (out, rr) in chunks.iter_mut().zip(r) {
             out.copy_from_slice(&rr.xyz);
         }
 
@@ -1130,7 +1131,7 @@ mod tests {
         println!(
             "pub(super) static CURVE_GENERATOR_PRECOMP_W5: super::JacobianMontPointTableW5 = ["
         );
-        for (i, point) in (1..).zip(precomp.chunks_exact(18)) {
+        for (i, point) in (1..).zip(precomp.as_chunks::<18>().0.iter()) {
             println!("// {i}G");
             for p in point {
                 println!("            0x{p:016x}, ");

--- a/graviola/src/mid/sha2.rs
+++ b/graviola/src/mid/sha2.rs
@@ -70,7 +70,8 @@ impl Sha256Context {
         self.update_blocks(last_blocks.as_ref());
 
         let mut r = [0u8; Self::OUTPUT_SZ];
-        for (out, state) in r.chunks_exact_mut(4).zip(self.h.iter()) {
+        let (chunks, _) = r.as_chunks_mut::<4>();
+        for (out, state) in chunks.iter_mut().zip(self.h.iter()) {
             out.copy_from_slice(&state.to_be_bytes());
         }
         r
@@ -200,7 +201,8 @@ impl Sha512Context {
         self.update_blocks(last_blocks.as_ref());
 
         let mut r = [0u8; Self::OUTPUT_SZ];
-        for (out, state) in r.chunks_exact_mut(8).zip(self.h.iter()) {
+        let (chunks, _) = r.as_chunks_mut::<8>();
+        for (out, state) in chunks.iter_mut().zip(self.h.iter()) {
             out.copy_from_slice(&state.to_be_bytes());
         }
         r

--- a/graviola/src/mid/sha3.rs
+++ b/graviola/src/mid/sha3.rs
@@ -148,26 +148,30 @@ impl Shake256 {
 
         let mut states = [
             {
-                for (i, inp) in inputs[0].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[0].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
             {
-                for (i, inp) in inputs[1].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[1].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
             {
-                for (i, inp) in inputs[2].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[2].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
             {
-                for (i, inp) in inputs[3].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[3].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
@@ -185,14 +189,16 @@ impl Shake256 {
         // by-4 keccak permutation, which is quicker on x86-64 than two by-1 keccak
         // permutations!
         states[0] = {
-            for (i, inp) in inputs[4].chunks_exact(8).enumerate() {
-                s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+            let (chunks, _) = inputs[4].as_chunks::<8>();
+            for (i, inp) in chunks.iter().enumerate() {
+                s[i] = u64::from_le_bytes(*inp);
             }
             s
         };
         states[1] = {
-            for (i, inp) in inputs[5].chunks_exact(8).enumerate() {
-                s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+            let (chunks, _) = inputs[5].as_chunks::<8>();
+            for (i, inp) in chunks.iter().enumerate() {
+                s[i] = u64::from_le_bytes(*inp);
             }
             s
         };
@@ -284,26 +290,30 @@ impl SqueezingSponge4xShake128 {
 
         let mut states = [
             {
-                for (i, inp) in inputs[0].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[0].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
             {
-                for (i, inp) in inputs[1].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[1].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
             {
-                for (i, inp) in inputs[2].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[2].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
             {
-                for (i, inp) in inputs[3].chunks_exact(8).enumerate() {
-                    s[i] = u64::from_le_bytes(inp.try_into().unwrap());
+                let (chunks, _) = inputs[3].as_chunks::<8>();
+                for (i, inp) in chunks.iter().enumerate() {
+                    s[i] = u64::from_le_bytes(*inp);
                 }
                 s
             },
@@ -331,7 +341,8 @@ impl SqueezingSponge4xShake128 {
         ) {
             for j in 0..4 {
                 debug_assert!(span.len().is_multiple_of(8));
-                for (i, ch) in output[j][span.clone()].chunks_exact_mut(8).enumerate() {
+                let (chunks, _) = output[j][span.clone()].as_chunks_mut::<8>();
+                for (i, ch) in chunks.iter_mut().enumerate() {
                     ch.copy_from_slice(&states[j][i].to_le_bytes());
                 }
             }
@@ -429,8 +440,9 @@ impl<const R: usize, const PAD: u8> Sponge<R, PAD> {
     }
 
     fn absorb_block(&mut self, block: &[u8; R]) {
-        for (i, block) in block.chunks_exact(8).enumerate() {
-            self.sponge.s[i] ^= u64::from_le_bytes(block.try_into().unwrap());
+        let (chunks, _) = block.as_chunks::<8>();
+        for (i, block) in chunks.iter().enumerate() {
+            self.sponge.s[i] ^= u64::from_le_bytes(*block);
         }
         sha3_keccak_f1600(&mut self.sponge.s, &RC);
     }


### PR DESCRIPTION
As of Rust 1.98.0, Clippy now warns about the use of `collection.chunks_exact(CONSTANT)`. This patch replaces it with the recommended new idiom `collection.as_chunks::<CONSTANT>`.

While the new idiom is more verbose, it has the positive side effect of eliminating the need for some `slice.try_into().unwrap()` expressions.