### PR TITLE
Use Mach-O relocation syntax on all Apple platforms

### DIFF
--- a/graviola/src/low/macros.rs
+++ b/graviola/src/low/macros.rs
@@ -36,24 +36,24 @@ macro_rules! Label {
 
 /// Plasters over the difference between ELF and Mach-O relocation
 /// syntax, for page-aligned items.  (Only makes sense on aarch64).
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 macro_rules! PageRef {
     ($sym:literal) => { Q!( "{" $sym "}@PAGE" ) }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 macro_rules! PageOffRef {
     ($sym:literal) => { Q!( "{" $sym "}@PAGEOFF" ) }
 }
 
 #[allow(unused_macros)]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(target_vendor = "apple"))]
 macro_rules! PageRef {
     ($sym:literal) => { Q!( "{" $sym "}" ) }
 }
 
 #[allow(unused_macros)]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(target_vendor = "apple"))]
 macro_rules! PageOffRef {
     ($sym:literal) => { Q!( ":lo12:" "{" $sym "}" ) }
 }


### PR DESCRIPTION
The `PageRef!` and `PageOffRef!` macros select relocation syntax on `target_os = "macos"`, so iOS, iPadOS, tvOS and watchOS take the ELF branch and assembly fails to link:

```
ADR/ADRP relocations must be GOT relative
```

Widening the condition to `target_vendor = "apple"` covers every Apple platform, since they all use Mach-O. Behaviour on macOS, Linux and Windows is unchanged.

Related to #133.

Verified by building `rustls-graviola` for `aarch64-apple-ios` and running a TLS client on an iPhone against a live server.