### PR TITLE
poly1305: use 64-bit limbs for faster computation

### DIFF
--- a/graviola/src/low/generic/poly1305.rs
+++ b/graviola/src/low/generic/poly1305.rs
@@ -1,22 +1,19 @@
 // Written for Graviola by Joe Birr-Pixton, 2024.
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
-// Originally from cifra, but later adopting the 32x32
-// multiplication layout from poly1305-donna.
+// Originally from cifra, but later adopting the 64x64
+// multiplication layout from aws-lc.
 
 use super::blockwise::Blockwise;
 
 pub(crate) struct Poly1305 {
-    /// Current accumulator
-    h: [u32; 5],
+    /// Current accumulator, 131 bits split into limbs of 64, 64, and 3 bits
+    h: [u64; 3],
 
-    /// Block multiplier
-    r: [u32; 5],
+    /// First half of key: block multiplier
+    r: [u64; 2],
 
-    /// r[1..5] times 5
-    r5: [u32; 4],
-
-    /// Final XOR offset
-    s: [u32; 4],
+    /// Second half of key: added to result
+    s: [u64; 2],
 
     /// Unprocessed input
     bw: Blockwise<16>,
@@ -24,25 +21,16 @@ pub(crate) struct Poly1305 {
 
 impl Poly1305 {
     pub(crate) fn new(key: &[u8; 32]) -> Self {
-        let h = [0; 5];
+        let h = [0; 3];
+        // Clamp r by ANDing it with 0x0ffffffc0ffffffc0ffffffc0fffffff (RFC 8439 section 2.5.1)
         let r = [
-            read32(&key[0..4]) & 0x3ffffff,
-            (read32(&key[3..7]) >> 2) & 0x3ffff03,
-            (read32(&key[6..10]) >> 4) & 0x3ffc0ff,
-            (read32(&key[9..13]) >> 6) & 0x3f03fff,
-            (read32(&key[12..16]) >> 8) & 0x00fffff,
+            read64(&key[0..8]) & 0x0ffffffc0fffffff,
+            read64(&key[8..16]) & 0x0ffffffc0ffffffc,
         ];
-        let r5 = [r[1] * 5, r[2] * 5, r[3] * 5, r[4] * 5];
-        let s = [
-            read32(&key[16..20]),
-            read32(&key[20..24]),
-            read32(&key[24..28]),
-            read32(&key[28..32]),
-        ];
+        let s = [read64(&key[16..24]), read64(&key[24..32])];
         Self {
             h,
             r,
-            r5,
             s,
             bw: Blockwise::new(),
         }
@@ -70,42 +58,20 @@ impl Poly1305 {
 
         full_reduce(&mut self.h);
 
-        // redistribute into 4 words
-        self.h[0] |= self.h[1] << 26;
-        self.h[1] = (self.h[1] >> 6) | (self.h[2] << 20);
-        self.h[2] = (self.h[2] >> 12) | (self.h[3] << 14);
-        self.h[3] = (self.h[3] >> 18) | (self.h[4] << 8);
-
         // add s with carry
-        fn add32(a: u32, b: u32) -> u64 {
-            (a as u64) + (b as u64)
-        }
-        let f = add32(self.h[0], self.s[0]);
-        self.h[0] = f as u32;
-        let f = add32(self.h[1], self.s[1]) + (f >> 32);
-        self.h[1] = f as u32;
-        let f = add32(self.h[2], self.s[2]) + (f >> 32);
-        self.h[2] = f as u32;
-        let f = add32(self.h[3], self.s[3]) + (f >> 32);
-        self.h[3] = f as u32;
+        let prev = self.h[0];
+        self.h[0] = self.h[0].wrapping_add(self.s[0]);
+        let carry = (self.h[0] < prev) as u64;
+        self.h[1] = self.h[1].wrapping_add(self.s[1]).wrapping_add(carry);
 
         let mut r = [0u8; 16];
-        r[0..4].copy_from_slice(&self.h[0].to_le_bytes());
-        r[4..8].copy_from_slice(&self.h[1].to_le_bytes());
-        r[8..12].copy_from_slice(&self.h[2].to_le_bytes());
-        r[12..16].copy_from_slice(&self.h[3].to_le_bytes());
-
+        r[0..8].copy_from_slice(&self.h[0].to_le_bytes());
+        r[8..16].copy_from_slice(&self.h[1].to_le_bytes());
         r
     }
 
     fn process_whole_block(&mut self, inp: &[u8; 16]) {
-        let block = [
-            read32(&inp[0..4]) & 0x3ff_ffff,
-            (read32(&inp[3..7]) >> 2) & 0x3ff_ffff,
-            (read32(&inp[6..10]) >> 4) & 0x3ff_ffff,
-            (read32(&inp[9..13]) >> 6) & 0x3ff_ffff,
-            (read32(&inp[12..16]) >> 8) | (1 << 24),
-        ];
+        let block = [read64(&inp[0..8]), read64(&inp[8..16]), 0x01];
         self.process_block(&block);
     }
 
@@ -114,147 +80,111 @@ impl Poly1305 {
         bytes[..inp.len()].copy_from_slice(inp);
         bytes[inp.len()] = 0x01;
 
-        let block = [
-            read32(&bytes[0..4]) & 0x3ff_ffff,
-            (read32(&bytes[3..7]) >> 2) & 0x3ff_ffff,
-            (read32(&bytes[6..10]) >> 4) & 0x3ff_ffff,
-            (read32(&bytes[9..13]) >> 6) & 0x3ff_ffff,
-            (read32(&bytes[12..16]) >> 8),
-        ];
+        let block = [read64(&bytes[0..8]), read64(&bytes[8..16]), 0];
         self.process_block(&block);
     }
 
-    fn process_block(&mut self, block: &[u32; 5]) {
+    fn process_block(&mut self, block: &[u64; 3]) {
         add(&mut self.h, block);
-        mul(&mut self.h, &self.r, &self.r5);
+        mul(&mut self.h, &self.r);
     }
 }
 
-fn read32(bytes: &[u8]) -> u32 {
-    u32::from_le_bytes(bytes.try_into().unwrap())
+fn read64(bytes: &[u8]) -> u64 {
+    u64::from_le_bytes(bytes.try_into().unwrap())
 }
 
-fn add(h: &mut [u32; 5], x: &[u32; 5]) {
-    h[0] = h[0].wrapping_add(x[0]);
-    h[1] = h[1].wrapping_add(x[1]);
+fn add(h: &mut [u64; 3], x: &[u64; 3]) {
+    // Add h += x, with carry. The generated code is a little less efficient
+    // than hand-written assembly, but this is portable.
+    // FIXME: try u64::carrying_add once the Graviola MSRV >= 1.91
+    let carry: bool;
+    (h[0], carry) = h[0].overflowing_add(x[0]);
+    let (carry1, carry2): (bool, bool);
+    (h[1], carry1) = h[1].overflowing_add(carry as u64);
+    (h[1], carry2) = h[1].overflowing_add(x[1]);
+    h[2] = h[2].wrapping_add((carry1 | carry2) as u64);
     h[2] = h[2].wrapping_add(x[2]);
-    h[3] = h[3].wrapping_add(x[3]);
-    h[4] = h[4].wrapping_add(x[4]);
 }
 
-fn mul(h: &mut [u32; 5], r: &[u32; 5], s: &[u32; 4]) {
-    fn mul32(a: u32, b: u32) -> u64 {
-        u64::from(a) * u64::from(b)
+fn mul(h: &mut [u64; 3], r: &[u64; 2]) {
+    fn mul64(a: u64, b: u64) -> (u64, u64) {
+        let product = (a as u128) * (b as u128);
+        (product as u64, (product >> 64) as u64)
     }
 
-    let d0 = mul32(h[0], r[0])
-        + mul32(h[1], s[3])
-        + mul32(h[2], s[2])
-        + mul32(h[3], s[1])
-        + mul32(h[4], s[0]);
-    let d1 = mul32(h[0], r[1])
-        + mul32(h[1], r[0])
-        + mul32(h[2], s[3])
-        + mul32(h[3], s[2])
-        + mul32(h[4], s[1]);
-    let d2 = mul32(h[0], r[2])
-        + mul32(h[1], r[1])
-        + mul32(h[2], r[0])
-        + mul32(h[3], s[3])
-        + mul32(h[4], s[2]);
-    let d3 = mul32(h[0], r[3])
-        + mul32(h[1], r[2])
-        + mul32(h[2], r[1])
-        + mul32(h[3], r[0])
-        + mul32(h[4], s[3]);
-    let d4 = mul32(h[0], r[4])
-        + mul32(h[1], r[3])
-        + mul32(h[2], r[2])
-        + mul32(h[3], r[1])
-        + mul32(h[4], r[0]);
+    // Multiply t = r * h
+    // The following implementation depends on these invariants to ensure that
+    // certain 64-bit addition and multiplication results fit in a u64:
+    //  * h uses at most 131 bits, and thus h[2] uses at most 3 bits
+    //  * r[0] uses at most 60 bits
+    //  * r[1] uses at most 60 bits
+    debug_assert!(h[2] < 1 << 3);
+    debug_assert!(r[0] < 1 << 60);
+    debug_assert!(r[1] < 1 << 60);
 
-    // partial reduction
-    let carry = d0 >> 26;
-    h[0] = (d0 & 0x3ff_ffff) as u32;
-    let d1 = d1 + carry;
-    let carry = d1 >> 26;
-    h[1] = (d1 & 0x3ff_ffff) as u32;
-    let d2 = d2 + carry;
-    let carry = d2 >> 26;
-    h[2] = (d2 & 0x3ff_ffff) as u32;
-    let d3 = d3 + carry;
-    let carry = d3 >> 26;
-    h[3] = (d3 & 0x3ff_ffff) as u32;
-    let d4 = d4 + carry;
-    let carry = (d4 >> 26) as u32;
-    h[4] = (d4 & 0x3ff_ffff) as u32;
-    h[0] += carry * 5;
-    let carry = h[0] >> 26;
-    h[0] &= 0x3ff_ffff;
-    h[1] += carry;
+    //         h[2] h[1] h[0]
+    // x                 r[0]
+    // ----------------------
+    //               d1   d0
+    //          d3   d2
+    //          d4
+    // ----------------------
+    //          e2   e1   e0
+    let (d0, d1) = mul64(r[0], h[0]);
+    let (d2, d3) = mul64(r[0], h[1]);
+    let d4 = r[0] * h[2];
+    let e0 = d0;
+    let (e1, carry) = d1.overflowing_add(d2);
+    let e2 = d3 + d4 + (carry as u64);
+
+    //         h[2] h[1] h[0]
+    // x            r[1]
+    // ----------------------
+    //          d1   d0
+    //     d3   d2
+    //     d4
+    // ----------------------
+    //     s5   e4   e3
+    let (d0, d1) = mul64(r[1], h[0]);
+    let (d2, d3) = mul64(r[1], h[1]);
+    let d4 = r[1] * h[2];
+    let e3 = d0;
+    let (e4, carry) = d1.overflowing_add(d2);
+    let e5 = d3 + d4 + (carry as u64);
+
+    //          e2   e1   e0
+    // +   e5   e4   e3
+    // ----------------------
+    //     f3   f2   f1   f0
+    let f0 = e0;
+    let (f1, carry) = e1.overflowing_add(e3);
+    let (f2, carry1) = e2.overflowing_add(carry as u64);
+    let (f2, carry2) = f2.overflowing_add(e4);
+    let f3 = e5 + ((carry1 | carry2) as u64);
+    debug_assert!(f3 < 1u64 << 63);
+
+    // Partially reduce the result so it fits within 131 bits
+    let (carry1, carry2): (bool, bool);
+    (h[0], carry1) = f0.overflowing_add(f2 & !0x03);
+    (h[0], carry2) = h[0].overflowing_add((f3 << 62) | (f2 >> 2));
+    let carry3: bool;
+    (h[1], carry3) = f1.overflowing_add(f3 + (f3 >> 2) + carry1 as u64 + carry2 as u64);
+    h[2] = (f2 & 0x03) + carry3 as u64;
 }
 
-fn full_reduce(h: &mut [u32; 5]) {
-    min_reduce(h);
-    maybe_sub_130_5(h);
-}
+fn full_reduce(h: &mut [u64; 3]) {
+    let (g0, carry0) = h[0].overflowing_sub(0u64.wrapping_sub(5));
+    let (g1, carry1a) = h[1].overflowing_sub(carry0 as u64);
+    let (g1, carry1b) = g1.overflowing_sub(0u64.wrapping_sub(1));
+    let (g2, carry2a) = h[2].overflowing_sub(carry1a as u64 + carry1b as u64);
+    let (g2, carry2b) = g2.overflowing_sub(3);
 
-fn min_reduce(h: &mut [u32; 5]) {
-    let carry = h[1] >> 26;
-    h[1] &= 0x3ffffff;
-    h[2] = h[2].wrapping_add(carry);
-
-    let carry = h[2] >> 26;
-    h[2] &= 0x3ffffff;
-    h[3] = h[3].wrapping_add(carry);
-
-    let carry = h[3] >> 26;
-    h[3] &= 0x3ffffff;
-    h[4] = h[4].wrapping_add(carry);
-
-    let carry = h[4] >> 26;
-    h[4] &= 0x3ffffff;
-    h[0] = h[0].wrapping_add(carry.wrapping_mul(5));
-
-    let carry = h[0] >> 26;
-    h[0] &= 0x3ffffff;
-    h[1] = h[1].wrapping_add(carry);
-}
-
-fn maybe_sub_130_5(h: &mut [u32; 5]) {
-    let g0 = h[0].wrapping_add(5);
-    let carry = g0 >> 26;
-    let g0 = g0 & 0x3ffffff;
-
-    let g1 = h[1].wrapping_add(carry);
-    let carry = g1 >> 26;
-    let g1 = g1 & 0x3ffffff;
-
-    let g2 = h[2].wrapping_add(carry);
-    let carry = g2 >> 26;
-    let g2 = g2 & 0x3ffffff;
-
-    let g3 = h[3].wrapping_add(carry);
-    let carry = g3 >> 26;
-    let g3 = g3 & 0x3ffffff;
-
-    let g4 = h[4].wrapping_add(carry).wrapping_sub(1 << 26);
-
-    let negative_mask = equal_mask(g4 & 0x80000000, 0x80000000);
-    let positive_mask = !negative_mask;
-
+    let positive_mask = ((carry2a | carry2b) as u64).wrapping_sub(1);
+    let negative_mask = !positive_mask;
     h[0] = (h[0] & negative_mask) | (g0 & positive_mask);
     h[1] = (h[1] & negative_mask) | (g1 & positive_mask);
     h[2] = (h[2] & negative_mask) | (g2 & positive_mask);
-    h[3] = (h[3] & negative_mask) | (g3 & positive_mask);
-    h[4] = (h[4] & negative_mask) | (g4 & positive_mask);
-}
-
-/// Produce 0xffffffff if x == y, zero
-fn equal_mask(x: u32, y: u32) -> u32 {
-    let diff = x ^ y;
-    let diff_is_zero = !diff & diff.wrapping_sub(1);
-    0u32.wrapping_sub(diff_is_zero >> 31)
 }
 
 #[cfg(test)]
@@ -290,6 +220,145 @@ mod tests {
             [
                 0xa6, 0xf7, 0x45, 0x00, 0x8f, 0x81, 0xc9, 0x16, 0xa2, 0x0d, 0xcc, 0x74, 0xee, 0xf2,
                 0xb2, 0xf0
+            ]
+        );
+
+        // From RFC 8439 appendix A.3 test vector #1
+        let key = &[0; 32];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[0; 64]);
+        assert_eq!(p.finish(), [0; 16]);
+
+        // From RFC 8439 appendix A.3 test vector #5
+        let key = &[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[0xff; 16]);
+        assert_eq!(
+            p.finish(),
+            [
+                0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00
+            ]
+        );
+
+        // From RFC 8439 appendix A.3 test vector #6
+        let key = &[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ]);
+        assert_eq!(
+            p.finish(),
+            [
+                0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00
+            ]
+        );
+
+        // From RFC 8439 appendix A.3 test vector #7
+        let key = &[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(
+            p.finish(),
+            [
+                0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00
+            ]
+        );
+
+        // From RFC 8439 appendix A.3 test vector #8
+        let key = &[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xfb, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe, 0xfe,
+            0xfe, 0xfe, 0xfe, 0xfe, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+        ]);
+        assert_eq!(p.finish(), [0; 16]);
+
+        // From RFC 8439 appendix A.3 test vector #9
+        let key = &[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[
+            0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff,
+        ]);
+        assert_eq!(
+            p.finish(),
+            [
+                0xfa, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff
+            ]
+        );
+
+        // From RFC 8439 appendix A.3 test vector #10
+        let key = &[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[
+            0xE3, 0x35, 0x94, 0xD7, 0x50, 0x5E, 0x43, 0xB9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x33, 0x94, 0xD7, 0x50, 0x5E, 0x43, 0x79, 0xCD, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(
+            p.finish(),
+            [
+                0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00
+            ]
+        );
+
+        // From RFC 8439 appendix A.3 test vector #11
+        let key = &[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut p = Poly1305::new(key);
+        p.add_bytes(&[
+            0xE3, 0x35, 0x94, 0xD7, 0x50, 0x5E, 0x43, 0xB9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x33, 0x94, 0xD7, 0x50, 0x5E, 0x43, 0x79, 0xCD, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(
+            p.finish(),
+            [
+                0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00
             ]
         );
     }


### PR DESCRIPTION
This replaces the 5x26-bit representation of 130-bit numbers with the three limbs of 64, 64, and 3 bits, following the layout used by aws-lc.