### PR TITLE
Generalize x86-cpuid to support other architectures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "graviola-cpuid"
+version = "0.1.0"
+
+[[package]]
 name = "graviola-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -3086,10 +3090,6 @@ dependencies = [
  "serde",
  "zeroize",
 ]
-
-[[package]]
-name = "x86-cpuid"
-version = "0.1.0"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ resolver = "2"
 members = [
   "graviola",
   "graviola-bench",
+  "graviola-cpuid",
   "rustls-graviola",
-  "fuzz",
-  "x86-cpuid"
+  "fuzz"
 ]
 
 [profile.bench]

--- a/admin/x86-cpu
+++ b/admin/x86-cpu
@@ -51,7 +51,7 @@ if mode == "sde-scan":
     for i, (flag, name) in enumerate(KNOWN_CPUS):
         env["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER"] = "sde {} --".format(flag)
         out = subprocess.check_output(
-            ["cargo", "run", "--bin", "x86-cpuid"], env=env, encoding="utf-8"
+            ["cargo", "run", "--bin", "graviola-cpuid"], env=env, encoding="utf-8"
         )
         js = json.loads(out)
         json.dump(

--- a/graviola-cpuid/Cargo.toml
+++ b/graviola-cpuid/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "x86-cpuid"
+name = "graviola-cpuid"
 version = "0.1.0"
 edition = "2024"
 

--- a/graviola-cpuid/src/main.rs
+++ b/graviola-cpuid/src/main.rs
@@ -1,6 +1,6 @@
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 fn main() {
-    println!("only for x86_64 architectures");
+    println!("only for x86_64 and aarch64 architectures");
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -46,5 +46,26 @@ fn main() {
         vpclmulqdq as u8,
         compatible as u8,
         avx512_aes_gcm as u8,
+    );
+}
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    use std::arch::is_aarch64_feature_detected;
+
+    let aes = is_aarch64_feature_detected!("aes");
+    let dit = is_aarch64_feature_detected!("dit");
+    let neon = is_aarch64_feature_detected!("neon");
+    let pmull = is_aarch64_feature_detected!("pmull");
+    let sha2 = is_aarch64_feature_detected!("sha2");
+    let sha3 = is_aarch64_feature_detected!("sha3");
+
+    let compatible = aes && neon && pmull && sha2;
+
+    println!(
+        "{{ \"cpuid\": {{ \"aes\": {}, \"dit\": {}, \"neon\": {}, \"pmull\": {}, \
+        \"sha2\": {}, \"sha3\": {} }}, \
+        \"compatible\": {} }}",
+        aes as u8, dit as u8, neon as u8, pmull as u8, sha2 as u8, sha3 as u8, compatible as u8,
     );
 }


### PR DESCRIPTION
* Rename to graviola-cpuid
* Add an aarch64 implementation